### PR TITLE
feat(compute-job-queue): add DAG-based job orchestration (#73)

### DIFF
--- a/src/compute-job-queue/compute-job-queue.module.ts
+++ b/src/compute-job-queue/compute-job-queue.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { BullModule } from '@nestjs/bull';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { EventEmitterModule } from '@nestjs/event-emitter';
@@ -7,6 +7,7 @@ import { ComputeJobProcessor } from './compute-job.processor';
 import { QueueHealthIndicator } from './compute-job-healt.indicators';
 import { CacheModule } from '../cache/cache.module';
 import { RetryPolicyService } from './retry-policy.service';
+import { DagModule } from './dag/dag.module';
 
 @Module({
   imports: [
@@ -58,6 +59,7 @@ import { RetryPolicyService } from './retry-policy.service';
     ),
     CacheModule,
     EventEmitterModule.forRoot(),
+    forwardRef(() => DagModule),
   ],
   providers: [
     QueueService,
@@ -65,6 +67,6 @@ import { RetryPolicyService } from './retry-policy.service';
     QueueHealthIndicator,
     RetryPolicyService,
   ],
-  exports: [QueueService, BullModule, CacheModule],
+  exports: [QueueService, BullModule, CacheModule, DagModule],
 })
 export class QueueModule {}

--- a/src/compute-job-queue/compute-job.processor.ts
+++ b/src/compute-job-queue/compute-job.processor.ts
@@ -70,6 +70,16 @@ export class ComputeJobProcessor {
         result,
       });
 
+      // Notify DAG orchestrator if this job belongs to a workflow
+      const dagCtx = job.data.metadata?.dagContext;
+      if (dagCtx?.workflowId && dagCtx?.nodeId) {
+        this.eventEmitter?.emit('dag.job.completed', {
+          workflowId: dagCtx.workflowId,
+          nodeId: dagCtx.nodeId,
+          result,
+        });
+      }
+
       return {
         success: true,
         data: result,
@@ -100,7 +110,17 @@ export class ComputeJobProcessor {
           jobType: job.data.type,
           error: error.message,
         });
-        
+
+        // Notify DAG orchestrator if this job belongs to a workflow
+        const dagCtx = job.data.metadata?.dagContext;
+        if (dagCtx?.workflowId && dagCtx?.nodeId) {
+          this.eventEmitter?.emit('dag.job.failed', {
+            workflowId: dagCtx.workflowId,
+            nodeId: dagCtx.nodeId,
+            error: error.message,
+          });
+        }
+
         return {
           success: false,
           error: error.message,

--- a/src/compute-job-queue/dag/dag.controller.ts
+++ b/src/compute-job-queue/dag/dag.controller.ts
@@ -1,0 +1,134 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Param,
+  Body,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+} from '@nestjs/swagger';
+import { DagService } from './dag.service';
+import {
+  CreateDagWorkflowDto,
+  DagWorkflowResponseDto,
+  DagValidationResponseDto,
+  DagNodeResponseDto,
+} from './dag.dto';
+import { DagWorkflow } from './dag.interfaces';
+
+@ApiTags('dag')
+@Controller('queue/dag')
+export class DagController {
+  constructor(private readonly dagService: DagService) {}
+
+  @Post('workflows')
+  @ApiOperation({ summary: 'Submit a new DAG workflow' })
+  @ApiResponse({
+    status: 201,
+    description: 'Workflow created and root jobs enqueued',
+    type: DagWorkflowResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid DAG structure' })
+  async submitWorkflow(
+    @Body() dto: CreateDagWorkflowDto,
+  ): Promise<DagWorkflowResponseDto> {
+    const workflow = await this.dagService.submitWorkflow(dto);
+    return this.toWorkflowResponse(workflow);
+  }
+
+  @Post('workflows/validate')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Validate a DAG structure without submitting' })
+  @ApiResponse({
+    status: 200,
+    description: 'Validation result',
+    type: DagValidationResponseDto,
+  })
+  validateWorkflow(
+    @Body() dto: CreateDagWorkflowDto,
+  ): DagValidationResponseDto {
+    const result = this.dagService.validateWorkflow(dto);
+    return {
+      valid: result.valid,
+      errors: result.errors,
+      topologicalOrder: result.topologicalOrder,
+    };
+  }
+
+  @Get('workflows')
+  @ApiOperation({ summary: 'List all DAG workflows' })
+  @ApiResponse({ status: 200, description: 'Workflow list returned' })
+  listWorkflows() {
+    return this.dagService.listWorkflows().map((wf) => ({
+      workflowId: wf.workflowId,
+      name: wf.name,
+      status: wf.status,
+      nodeCount: wf.nodeCount,
+      createdAt: wf.createdAt.toISOString(),
+    }));
+  }
+
+  @Get('workflows/:id')
+  @ApiOperation({ summary: 'Get a DAG workflow by ID' })
+  @ApiParam({ name: 'id', description: 'Workflow ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Workflow details returned',
+    type: DagWorkflowResponseDto,
+  })
+  @ApiResponse({ status: 404, description: 'Workflow not found' })
+  getWorkflow(@Param('id') id: string): DagWorkflowResponseDto {
+    const workflow = this.dagService.getWorkflow(id);
+    return this.toWorkflowResponse(workflow);
+  }
+
+  @Post('workflows/:id/cancel')
+  @ApiOperation({ summary: 'Cancel a running DAG workflow' })
+  @ApiParam({ name: 'id', description: 'Workflow ID' })
+  @ApiResponse({ status: 200, description: 'Workflow cancelled' })
+  @ApiResponse({ status: 400, description: 'Workflow already completed' })
+  @ApiResponse({ status: 404, description: 'Workflow not found' })
+  async cancelWorkflow(
+    @Param('id') id: string,
+  ): Promise<DagWorkflowResponseDto> {
+    const workflow = await this.dagService.cancelWorkflow(id);
+    return this.toWorkflowResponse(workflow);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Response mapping
+  // ---------------------------------------------------------------------------
+
+  private toWorkflowResponse(workflow: DagWorkflow): DagWorkflowResponseDto {
+    const nodes: DagNodeResponseDto[] = Array.from(
+      workflow.nodes.values(),
+    ).map((node) => ({
+      jobId: node.jobId,
+      type: node.type,
+      status: node.status,
+      queueJobId: node.queueJobId,
+      result: node.result,
+      error: node.error,
+      dependsOn: node.dependsOn.map((d) => ({
+        jobId: d.jobId,
+        condition: d.condition,
+      })),
+    }));
+
+    return {
+      workflowId: workflow.workflowId,
+      name: workflow.name,
+      status: workflow.status,
+      nodes,
+      topologicalOrder: workflow.topologicalOrder,
+      createdAt: workflow.createdAt.toISOString(),
+      completedAt: workflow.completedAt?.toISOString(),
+    };
+  }
+}

--- a/src/compute-job-queue/dag/dag.dto.ts
+++ b/src/compute-job-queue/dag/dag.dto.ts
@@ -1,0 +1,204 @@
+import {
+  IsString,
+  IsOptional,
+  IsObject,
+  IsNumber,
+  IsArray,
+  IsEnum,
+  ValidateNested,
+  Min,
+  Max,
+  ArrayMinSize,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { DependencyCondition, DagNodeStatus, DagWorkflowStatus } from './dag.interfaces';
+
+/** Describes a single dependency edge in the request payload. */
+export class DagDependencyDto {
+  @ApiProperty({
+    description: 'ID of the upstream job this node depends on',
+    example: 'extract-data',
+  })
+  @IsString()
+  jobId: string;
+
+  @ApiPropertyOptional({
+    description: 'Condition under which the dependent job should run',
+    enum: DependencyCondition,
+    default: DependencyCondition.ON_SUCCESS,
+    example: DependencyCondition.ON_SUCCESS,
+  })
+  @IsOptional()
+  @IsEnum(DependencyCondition)
+  condition?: DependencyCondition = DependencyCondition.ON_SUCCESS;
+}
+
+/** Describes a single node (job) within the workflow submission. */
+export class CreateDagNodeDto {
+  @ApiProperty({
+    description: 'Unique job identifier within the workflow',
+    example: 'extract-data',
+  })
+  @IsString()
+  jobId: string;
+
+  @ApiProperty({
+    description: 'Job type routed to the processor',
+    example: 'data-processing',
+  })
+  @IsString()
+  type: string;
+
+  @ApiProperty({
+    description: 'Job payload data',
+    example: { source: 's3://bucket/raw-data.csv' },
+  })
+  @IsObject()
+  payload: any;
+
+  @ApiPropertyOptional({
+    description: 'User ID who owns this job',
+    example: 'user-123',
+  })
+  @IsOptional()
+  @IsString()
+  userId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Queue priority (lower = higher priority)',
+    example: 5,
+    minimum: 1,
+    maximum: 100,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  @Max(100)
+  priority?: number;
+
+  @ApiPropertyOptional({
+    description: 'Grouping key for correlation',
+    example: 'ml-pipeline-run-42',
+  })
+  @IsOptional()
+  @IsString()
+  groupKey?: string;
+
+  @ApiPropertyOptional({
+    description: 'Additional metadata forwarded to the job',
+    example: { retries: 2 },
+  })
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>;
+
+  @ApiPropertyOptional({
+    description: 'Upstream dependencies with optional conditions',
+    type: [DagDependencyDto],
+    example: [{ jobId: 'extract-data', condition: 'onSuccess' }],
+  })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => DagDependencyDto)
+  dependsOn?: DagDependencyDto[];
+}
+
+/** Top-level request body to submit a DAG workflow. */
+export class CreateDagWorkflowDto {
+  @ApiPropertyOptional({
+    description: 'Human-readable workflow name',
+    example: 'ML Training Pipeline',
+  })
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @ApiProperty({
+    description: 'Nodes (jobs) that compose the workflow',
+    type: [CreateDagNodeDto],
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => CreateDagNodeDto)
+  nodes: CreateDagNodeDto[];
+
+  @ApiPropertyOptional({
+    description: 'User ID who submitted the workflow',
+    example: 'user-123',
+  })
+  @IsOptional()
+  @IsString()
+  userId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Workflow-level metadata',
+    example: { environment: 'staging' },
+  })
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>;
+}
+
+// ---------------------------------------------------------------------------
+// Response DTOs
+// ---------------------------------------------------------------------------
+
+export class DagNodeResponseDto {
+  @ApiProperty({ example: 'extract-data' })
+  jobId: string;
+
+  @ApiProperty({ example: 'data-processing' })
+  type: string;
+
+  @ApiProperty({ enum: DagNodeStatus, example: DagNodeStatus.PENDING })
+  status: DagNodeStatus;
+
+  @ApiPropertyOptional()
+  queueJobId?: string;
+
+  @ApiPropertyOptional()
+  result?: any;
+
+  @ApiPropertyOptional()
+  error?: string;
+
+  @ApiPropertyOptional({ type: [DagDependencyDto] })
+  dependsOn?: DagDependencyDto[];
+}
+
+export class DagWorkflowResponseDto {
+  @ApiProperty({ example: 'wf-abc123' })
+  workflowId: string;
+
+  @ApiPropertyOptional({ example: 'ML Training Pipeline' })
+  name?: string;
+
+  @ApiProperty({ enum: DagWorkflowStatus })
+  status: DagWorkflowStatus;
+
+  @ApiProperty({ type: [DagNodeResponseDto] })
+  nodes: DagNodeResponseDto[];
+
+  @ApiProperty({ description: 'Topological execution order', type: [String] })
+  topologicalOrder: string[];
+
+  @ApiProperty({ example: '2026-02-24T09:00:00.000Z' })
+  createdAt: string;
+
+  @ApiPropertyOptional({ example: '2026-02-24T09:05:00.000Z' })
+  completedAt?: string;
+}
+
+export class DagValidationResponseDto {
+  @ApiProperty({ example: true })
+  valid: boolean;
+
+  @ApiProperty({ type: [String], example: [] })
+  errors: string[];
+
+  @ApiPropertyOptional({ type: [String] })
+  topologicalOrder?: string[];
+}

--- a/src/compute-job-queue/dag/dag.integration.spec.ts
+++ b/src/compute-job-queue/dag/dag.integration.spec.ts
@@ -1,0 +1,487 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { DagService } from './dag.service';
+import { DagValidator } from './dag.validator';
+import { QueueService } from '../queue.service';
+import { CreateDagWorkflowDto } from './dag.dto';
+import {
+  DagNodeStatus,
+  DagWorkflowStatus,
+  DependencyCondition,
+} from './dag.interfaces';
+
+/**
+ * Integration tests for multi-stage DAG pipelines.
+ *
+ * These tests simulate realistic workflow scenarios including:
+ *  - ETL (Extract → Transform → Load) pipelines
+ *  - Conditional branching (error-handler paths)
+ *  - Parallel fan-out / fan-in patterns
+ *  - Error propagation and partial completion
+ */
+describe('DAG Integration Tests', () => {
+  let service: DagService;
+  let eventEmitter: EventEmitter2;
+  let addJobSpy: jest.Mock;
+
+  beforeEach(async () => {
+    addJobSpy = jest.fn().mockResolvedValue({ id: 'mock-bull-job' });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DagService,
+        DagValidator,
+        {
+          provide: QueueService,
+          useValue: { addComputeJob: addJobSpy },
+        },
+        {
+          provide: EventEmitter2,
+          useValue: new EventEmitter2(),
+        },
+      ],
+    }).compile();
+
+    service = module.get<DagService>(DagService);
+    eventEmitter = module.get(EventEmitter2);
+  });
+
+  /** Helper: emit completion and wait for async propagation. */
+  async function completeNode(
+    workflowId: string,
+    nodeId: string,
+    result: any = {},
+  ) {
+    eventEmitter.emit('dag.job.completed', { workflowId, nodeId, result });
+    await tick();
+  }
+
+  /** Helper: emit failure and wait for async propagation. */
+  async function failNode(
+    workflowId: string,
+    nodeId: string,
+    error = 'test error',
+  ) {
+    eventEmitter.emit('dag.job.failed', { workflowId, nodeId, error });
+    await tick();
+  }
+
+  async function tick(ms = 50) {
+    await new Promise((r) => setTimeout(r, ms));
+  }
+
+  // -----------------------------------------------------------------------
+  // Scenario 1: Simple ETL pipeline (Extract → Transform → Load)
+  // -----------------------------------------------------------------------
+  describe('ETL pipeline: extract → transform → load', () => {
+    let workflowId: string;
+
+    beforeEach(async () => {
+      const dto: CreateDagWorkflowDto = {
+        name: 'ETL Pipeline',
+        nodes: [
+          {
+            jobId: 'extract',
+            type: 'data-processing',
+            payload: { source: 's3://bucket/raw' },
+          },
+          {
+            jobId: 'transform',
+            type: 'data-processing',
+            payload: { mode: 'normalize' },
+            dependsOn: [
+              { jobId: 'extract', condition: DependencyCondition.ON_SUCCESS },
+            ],
+          },
+          {
+            jobId: 'load',
+            type: 'data-processing',
+            payload: { target: 'warehouse' },
+            dependsOn: [
+              { jobId: 'transform', condition: DependencyCondition.ON_SUCCESS },
+            ],
+          },
+        ],
+        userId: 'etl-user',
+      };
+
+      const wf = await service.submitWorkflow(dto);
+      workflowId = wf.workflowId;
+    });
+
+    it('should execute all three stages sequentially', async () => {
+      // Only extract should be enqueued initially
+      expect(addJobSpy).toHaveBeenCalledTimes(1);
+
+      await completeNode(workflowId, 'extract', { rows: 1000 });
+      expect(addJobSpy).toHaveBeenCalledTimes(2);
+
+      await completeNode(workflowId, 'transform', { rows: 950 });
+      expect(addJobSpy).toHaveBeenCalledTimes(3);
+
+      await completeNode(workflowId, 'load', { loaded: true });
+
+      const wf = service.getWorkflow(workflowId);
+      expect(wf.status).toBe(DagWorkflowStatus.COMPLETED);
+      expect(wf.nodes.get('extract').status).toBe(DagNodeStatus.COMPLETED);
+      expect(wf.nodes.get('transform').status).toBe(DagNodeStatus.COMPLETED);
+      expect(wf.nodes.get('load').status).toBe(DagNodeStatus.COMPLETED);
+    });
+
+    it('should propagate upstream results to downstream nodes', async () => {
+      await completeNode(workflowId, 'extract', { rows: 500, format: 'csv' });
+
+      // The transform job should receive extract's result in dagContext
+      const transformCall = addJobSpy.mock.calls[1][0];
+      expect(transformCall.metadata.dagContext.upstreamResults).toEqual({
+        extract: { rows: 500, format: 'csv' },
+      });
+    });
+
+    it('should skip transform and load when extract fails', async () => {
+      await failNode(workflowId, 'extract', 'S3 connection timeout');
+
+      const wf = service.getWorkflow(workflowId);
+      expect(wf.nodes.get('extract').status).toBe(DagNodeStatus.FAILED);
+      expect(wf.nodes.get('transform').status).toBe(DagNodeStatus.SKIPPED);
+      expect(wf.nodes.get('load').status).toBe(DagNodeStatus.SKIPPED);
+      expect(wf.status).toBe(DagWorkflowStatus.FAILED);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Scenario 2: Conditional branching with error handler
+  // -----------------------------------------------------------------------
+  describe('Conditional branching: success path + error handler', () => {
+    it('should run error-handler when main job fails', async () => {
+      const dto: CreateDagWorkflowDto = {
+        name: 'Conditional Pipeline',
+        nodes: [
+          {
+            jobId: 'process',
+            type: 'ai-computation',
+            payload: { model: 'gpt-4' },
+          },
+          {
+            jobId: 'publish',
+            type: 'data-processing',
+            payload: { target: 'api' },
+            dependsOn: [
+              { jobId: 'process', condition: DependencyCondition.ON_SUCCESS },
+            ],
+          },
+          {
+            jobId: 'alert',
+            type: 'email-notification',
+            payload: { to: 'ops@example.com' },
+            dependsOn: [
+              { jobId: 'process', condition: DependencyCondition.ON_FAILURE },
+            ],
+          },
+          {
+            jobId: 'cleanup',
+            type: 'data-processing',
+            payload: { action: 'cleanup' },
+            dependsOn: [
+              { jobId: 'process', condition: DependencyCondition.ALWAYS },
+            ],
+          },
+        ],
+      };
+
+      const wf = await service.submitWorkflow(dto);
+
+      // process fails
+      await failNode(wf.workflowId, 'process', 'Model unavailable');
+
+      const workflow = service.getWorkflow(wf.workflowId);
+
+      // publish should be SKIPPED (onSuccess condition not met)
+      expect(workflow.nodes.get('publish').status).toBe(DagNodeStatus.SKIPPED);
+
+      // alert should have been enqueued (onFailure condition met)
+      const alertEnqueued = addJobSpy.mock.calls.some(
+        (call) => call[0].metadata?.dagContext?.nodeId === 'alert',
+      );
+      expect(alertEnqueued).toBe(true);
+
+      // cleanup should have been enqueued (ALWAYS condition met)
+      const cleanupEnqueued = addJobSpy.mock.calls.some(
+        (call) => call[0].metadata?.dagContext?.nodeId === 'cleanup',
+      );
+      expect(cleanupEnqueued).toBe(true);
+    });
+
+    it('should run publish (not alert) when main job succeeds', async () => {
+      const dto: CreateDagWorkflowDto = {
+        name: 'Happy Path',
+        nodes: [
+          {
+            jobId: 'process',
+            type: 'ai-computation',
+            payload: {},
+          },
+          {
+            jobId: 'publish',
+            type: 'data-processing',
+            payload: {},
+            dependsOn: [
+              { jobId: 'process', condition: DependencyCondition.ON_SUCCESS },
+            ],
+          },
+          {
+            jobId: 'alert',
+            type: 'email-notification',
+            payload: { to: 'ops@example.com' },
+            dependsOn: [
+              { jobId: 'process', condition: DependencyCondition.ON_FAILURE },
+            ],
+          },
+        ],
+      };
+
+      const wf = await service.submitWorkflow(dto);
+      await completeNode(wf.workflowId, 'process', { output: 'ok' });
+
+      const workflow = service.getWorkflow(wf.workflowId);
+
+      // alert should be SKIPPED (onFailure not met since process succeeded)
+      expect(workflow.nodes.get('alert').status).toBe(DagNodeStatus.SKIPPED);
+
+      // publish should have been enqueued
+      const publishEnqueued = addJobSpy.mock.calls.some(
+        (call) => call[0].metadata?.dagContext?.nodeId === 'publish',
+      );
+      expect(publishEnqueued).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Scenario 3: Parallel fan-out / fan-in
+  // -----------------------------------------------------------------------
+  describe('Parallel fan-out / fan-in', () => {
+    it('should enqueue join only after all parallel branches complete', async () => {
+      const dto: CreateDagWorkflowDto = {
+        name: 'Fan-out Fan-in',
+        nodes: [
+          { jobId: 'split', type: 'data-processing', payload: {} },
+          {
+            jobId: 'branch-a',
+            type: 'data-processing',
+            payload: { partition: 'A' },
+            dependsOn: [
+              { jobId: 'split', condition: DependencyCondition.ON_SUCCESS },
+            ],
+          },
+          {
+            jobId: 'branch-b',
+            type: 'data-processing',
+            payload: { partition: 'B' },
+            dependsOn: [
+              { jobId: 'split', condition: DependencyCondition.ON_SUCCESS },
+            ],
+          },
+          {
+            jobId: 'branch-c',
+            type: 'data-processing',
+            payload: { partition: 'C' },
+            dependsOn: [
+              { jobId: 'split', condition: DependencyCondition.ON_SUCCESS },
+            ],
+          },
+          {
+            jobId: 'join',
+            type: 'report-generation',
+            payload: {},
+            dependsOn: [
+              { jobId: 'branch-a', condition: DependencyCondition.ON_SUCCESS },
+              { jobId: 'branch-b', condition: DependencyCondition.ON_SUCCESS },
+              { jobId: 'branch-c', condition: DependencyCondition.ON_SUCCESS },
+            ],
+          },
+        ],
+      };
+
+      const wf = await service.submitWorkflow(dto);
+      const wfId = wf.workflowId;
+
+      // split enqueued
+      expect(addJobSpy).toHaveBeenCalledTimes(1);
+
+      await completeNode(wfId, 'split', { parts: 3 });
+      // 3 branches enqueued
+      expect(addJobSpy).toHaveBeenCalledTimes(4);
+
+      // Complete branches one by one – join should NOT fire until all done
+      await completeNode(wfId, 'branch-a', { partA: true });
+      expect(addJobSpy).toHaveBeenCalledTimes(4); // still 4
+
+      await completeNode(wfId, 'branch-b', { partB: true });
+      expect(addJobSpy).toHaveBeenCalledTimes(4); // still 4
+
+      await completeNode(wfId, 'branch-c', { partC: true });
+      // Now join should be enqueued
+      expect(addJobSpy).toHaveBeenCalledTimes(5);
+
+      // Verify join receives all upstream results
+      const joinCall = addJobSpy.mock.calls[4][0];
+      expect(joinCall.metadata.dagContext.upstreamResults).toEqual({
+        'branch-a': { partA: true },
+        'branch-b': { partB: true },
+        'branch-c': { partC: true },
+      });
+
+      await completeNode(wfId, 'join', { merged: true });
+
+      const workflow = service.getWorkflow(wfId);
+      expect(workflow.status).toBe(DagWorkflowStatus.COMPLETED);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Scenario 4: Error propagation in a deep pipeline
+  // -----------------------------------------------------------------------
+  describe('Error propagation in deep pipeline', () => {
+    it('should skip all downstream nodes when a mid-pipeline node fails', async () => {
+      const dto: CreateDagWorkflowDto = {
+        name: 'Deep Pipeline',
+        nodes: [
+          { jobId: 's1', type: 'data-processing', payload: {} },
+          {
+            jobId: 's2',
+            type: 'data-processing',
+            payload: {},
+            dependsOn: [{ jobId: 's1', condition: DependencyCondition.ON_SUCCESS }],
+          },
+          {
+            jobId: 's3',
+            type: 'data-processing',
+            payload: {},
+            dependsOn: [{ jobId: 's2', condition: DependencyCondition.ON_SUCCESS }],
+          },
+          {
+            jobId: 's4',
+            type: 'data-processing',
+            payload: {},
+            dependsOn: [{ jobId: 's3', condition: DependencyCondition.ON_SUCCESS }],
+          },
+        ],
+      };
+
+      const wf = await service.submitWorkflow(dto);
+
+      await completeNode(wf.workflowId, 's1', {});
+      await failNode(wf.workflowId, 's2', 'disk full');
+
+      const workflow = service.getWorkflow(wf.workflowId);
+      expect(workflow.nodes.get('s1').status).toBe(DagNodeStatus.COMPLETED);
+      expect(workflow.nodes.get('s2').status).toBe(DagNodeStatus.FAILED);
+      expect(workflow.nodes.get('s3').status).toBe(DagNodeStatus.SKIPPED);
+      expect(workflow.nodes.get('s4').status).toBe(DagNodeStatus.SKIPPED);
+      expect(workflow.status).toBe(DagWorkflowStatus.PARTIALLY_COMPLETED);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Scenario 5: onPartialSuccess condition
+  // -----------------------------------------------------------------------
+  describe('onPartialSuccess condition', () => {
+    it('should trigger on both success and failure', async () => {
+      const dto: CreateDagWorkflowDto = {
+        name: 'Partial Success',
+        nodes: [
+          { jobId: 'risky', type: 'ai-computation', payload: {} },
+          {
+            jobId: 'summary',
+            type: 'report-generation',
+            payload: {},
+            dependsOn: [
+              { jobId: 'risky', condition: DependencyCondition.ON_PARTIAL_SUCCESS },
+            ],
+          },
+        ],
+      };
+
+      // Test with failure
+      const wf1 = await service.submitWorkflow(dto);
+      await failNode(wf1.workflowId, 'risky', 'timeout');
+
+      const summaryEnqueued = addJobSpy.mock.calls.some(
+        (call) => call[0].metadata?.dagContext?.nodeId === 'summary',
+      );
+      expect(summaryEnqueued).toBe(true);
+    });
+
+    it('should also trigger on success', async () => {
+      addJobSpy.mockClear();
+
+      const dto: CreateDagWorkflowDto = {
+        name: 'Partial Success Happy Path',
+        nodes: [
+          { jobId: 'risky', type: 'ai-computation', payload: {} },
+          {
+            jobId: 'summary',
+            type: 'report-generation',
+            payload: {},
+            dependsOn: [
+              { jobId: 'risky', condition: DependencyCondition.ON_PARTIAL_SUCCESS },
+            ],
+          },
+        ],
+      };
+
+      const wf2 = await service.submitWorkflow(dto);
+      await completeNode(wf2.workflowId, 'risky', { data: 'ok' });
+
+      const summaryEnqueued = addJobSpy.mock.calls.some(
+        (call) => call[0].metadata?.dagContext?.nodeId === 'summary',
+      );
+      expect(summaryEnqueued).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Scenario 6: Workflow cancellation mid-flight
+  // -----------------------------------------------------------------------
+  describe('Workflow cancellation', () => {
+    it('should prevent further nodes from executing after cancellation', async () => {
+      const dto: CreateDagWorkflowDto = {
+        name: 'Cancellable Pipeline',
+        nodes: [
+          { jobId: 'a', type: 'data-processing', payload: {} },
+          {
+            jobId: 'b',
+            type: 'data-processing',
+            payload: {},
+            dependsOn: [{ jobId: 'a', condition: DependencyCondition.ON_SUCCESS }],
+          },
+          {
+            jobId: 'c',
+            type: 'data-processing',
+            payload: {},
+            dependsOn: [{ jobId: 'b', condition: DependencyCondition.ON_SUCCESS }],
+          },
+        ],
+      };
+
+      const wf = await service.submitWorkflow(dto);
+
+      // Complete 'a'
+      await completeNode(wf.workflowId, 'a', {});
+
+      // Cancel the workflow while 'b' is running
+      await service.cancelWorkflow(wf.workflowId);
+
+      const workflow = service.getWorkflow(wf.workflowId);
+      expect(workflow.status).toBe(DagWorkflowStatus.CANCELLED);
+
+      // 'c' should be CANCELLED since it was still PENDING
+      expect(workflow.nodes.get('c').status).toBe(DagNodeStatus.CANCELLED);
+
+      // Even if b "completes" after cancellation, no new nodes should enqueue
+      const callsBefore = addJobSpy.mock.calls.length;
+      await completeNode(wf.workflowId, 'b', {});
+      expect(addJobSpy.mock.calls.length).toBe(callsBefore);
+    });
+  });
+});

--- a/src/compute-job-queue/dag/dag.interfaces.ts
+++ b/src/compute-job-queue/dag/dag.interfaces.ts
@@ -1,0 +1,113 @@
+/**
+ * Core interfaces for the DAG-based job orchestration system.
+ *
+ * A DAG workflow groups multiple compute jobs with explicit
+ * dependency edges, optional execution conditions, and a shared
+ * result context so downstream jobs can consume upstream outputs.
+ */
+
+/** Condition under which a dependent job should execute. */
+export enum DependencyCondition {
+  ON_SUCCESS = 'onSuccess',
+  ON_FAILURE = 'onFailure',
+  ON_PARTIAL_SUCCESS = 'onPartialSuccess',
+  ALWAYS = 'always',
+}
+
+/** Lifecycle status of an individual DAG node (job). */
+export enum DagNodeStatus {
+  PENDING = 'pending',
+  QUEUED = 'queued',
+  RUNNING = 'running',
+  COMPLETED = 'completed',
+  FAILED = 'failed',
+  SKIPPED = 'skipped',
+  CANCELLED = 'cancelled',
+}
+
+/** Lifecycle status of the overall DAG workflow. */
+export enum DagWorkflowStatus {
+  PENDING = 'pending',
+  RUNNING = 'running',
+  COMPLETED = 'completed',
+  FAILED = 'failed',
+  PARTIALLY_COMPLETED = 'partially_completed',
+  CANCELLED = 'cancelled',
+}
+
+/** A single dependency edge: "this node depends on `jobId` under `condition`." */
+export interface DagDependency {
+  jobId: string;
+  condition: DependencyCondition;
+}
+
+/** One node in the DAG – wraps a compute job with dependency metadata. */
+export interface DagNode {
+  /** Unique identifier within the workflow (user-supplied or generated). */
+  jobId: string;
+  /** Job type routed to the processor (maps to ComputeJobData.type). */
+  type: string;
+  /** Arbitrary payload forwarded to the job processor. */
+  payload: any;
+  /** Optional owning user. */
+  userId?: string;
+  /** Queue priority (lower = higher). */
+  priority?: number;
+  /** Grouping key for correlation. */
+  groupKey?: string;
+  /** Extra metadata forwarded to the job. */
+  metadata?: Record<string, any>;
+  /** Upstream dependencies with execution conditions. */
+  dependsOn: DagDependency[];
+  /** Runtime status – managed by the DAG service. */
+  status: DagNodeStatus;
+  /** Result stored after the job completes (success or failure). */
+  result?: any;
+  /** Error message if the job failed. */
+  error?: string;
+  /** Bull queue job ID once enqueued. */
+  queueJobId?: string;
+}
+
+/** Full DAG workflow stored in memory / DB. */
+export interface DagWorkflow {
+  /** Unique workflow identifier. */
+  workflowId: string;
+  /** Human-readable label. */
+  name?: string;
+  /** All nodes keyed by jobId for O(1) lookup. */
+  nodes: Map<string, DagNode>;
+  /** Adjacency list: parent jobId → set of child jobIds. */
+  edges: Map<string, Set<string>>;
+  /** Reverse adjacency: child jobId → set of parent jobIds. */
+  reverseEdges: Map<string, Set<string>>;
+  /** Overall status. */
+  status: DagWorkflowStatus;
+  /** Topologically sorted node IDs (computed once at validation time). */
+  topologicalOrder: string[];
+  /** Timestamp of workflow creation. */
+  createdAt: Date;
+  /** Timestamp of workflow completion (success, failure, or cancellation). */
+  completedAt?: Date;
+  /** The user who submitted the workflow. */
+  userId?: string;
+  /** Arbitrary workflow-level metadata. */
+  metadata?: Record<string, any>;
+}
+
+/** Lightweight result struct passed between DAG stages. */
+export interface DagJobContext {
+  /** Mapping of upstream jobId → its result data. */
+  upstreamResults: Record<string, any>;
+  /** The workflow this job belongs to. */
+  workflowId: string;
+  /** This node's jobId within the workflow. */
+  nodeId: string;
+}
+
+/** Validation result returned by the DAG validator. */
+export interface DagValidationResult {
+  valid: boolean;
+  errors: string[];
+  topologicalOrder?: string[];
+}

--- a/src/compute-job-queue/dag/dag.module.ts
+++ b/src/compute-job-queue/dag/dag.module.ts
@@ -1,0 +1,20 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { DagValidator } from './dag.validator';
+import { DagService } from './dag.service';
+import { DagController } from './dag.controller';
+import { QueueModule } from '../compute-job-queue.module';
+
+/**
+ * Provides DAG-based job orchestration on top of the existing
+ * compute job queue infrastructure.
+ *
+ * Imports QueueModule (via forwardRef to avoid circular dependency)
+ * so that DagService can inject QueueService for job enqueuing.
+ */
+@Module({
+  imports: [forwardRef(() => QueueModule)],
+  controllers: [DagController],
+  providers: [DagValidator, DagService],
+  exports: [DagService, DagValidator],
+})
+export class DagModule {}

--- a/src/compute-job-queue/dag/dag.service.spec.ts
+++ b/src/compute-job-queue/dag/dag.service.spec.ts
@@ -1,0 +1,495 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { DagService } from './dag.service';
+import { DagValidator } from './dag.validator';
+import { QueueService } from '../queue.service';
+import { CreateDagWorkflowDto } from './dag.dto';
+import {
+  DagNodeStatus,
+  DagWorkflowStatus,
+  DependencyCondition,
+} from './dag.interfaces';
+
+describe('DagService', () => {
+  let service: DagService;
+  let queueService: jest.Mocked<Partial<QueueService>>;
+  let eventEmitter: EventEmitter2;
+
+  const mockQueueService = {
+    addComputeJob: jest.fn().mockResolvedValue({ id: 'bull-job-1' }),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DagService,
+        DagValidator,
+        {
+          provide: QueueService,
+          useValue: mockQueueService,
+        },
+        {
+          provide: EventEmitter2,
+          useValue: new EventEmitter2(),
+        },
+      ],
+    }).compile();
+
+    service = module.get<DagService>(DagService);
+    queueService = module.get(QueueService);
+    eventEmitter = module.get(EventEmitter2);
+
+    jest.clearAllMocks();
+    mockQueueService.addComputeJob.mockResolvedValue({ id: 'bull-job-1' });
+  });
+
+  describe('submitWorkflow', () => {
+    it('should create a workflow and enqueue root nodes', async () => {
+      const dto: CreateDagWorkflowDto = {
+        name: 'Test Pipeline',
+        nodes: [
+          { jobId: 'extract', type: 'data-processing', payload: { src: 'db' } },
+          {
+            jobId: 'transform',
+            type: 'data-processing',
+            payload: { mode: 'clean' },
+            dependsOn: [{ jobId: 'extract', condition: DependencyCondition.ON_SUCCESS }],
+          },
+        ],
+        userId: 'user-1',
+      };
+
+      const workflow = await service.submitWorkflow(dto);
+
+      expect(workflow.workflowId).toBeDefined();
+      expect(workflow.name).toBe('Test Pipeline');
+      expect(workflow.status).toBe(DagWorkflowStatus.RUNNING);
+      expect(workflow.nodes.size).toBe(2);
+      expect(workflow.topologicalOrder[0]).toBe('extract');
+
+      // Root node 'extract' should have been enqueued
+      expect(mockQueueService.addComputeJob).toHaveBeenCalledTimes(1);
+      expect(mockQueueService.addComputeJob).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'data-processing',
+          metadata: expect.objectContaining({
+            dagContext: expect.objectContaining({
+              nodeId: 'extract',
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('should reject duplicate node IDs', async () => {
+      const dto: CreateDagWorkflowDto = {
+        nodes: [
+          { jobId: 'dup', type: 'data-processing', payload: {} },
+          { jobId: 'dup', type: 'data-processing', payload: {} },
+        ],
+      };
+
+      await expect(service.submitWorkflow(dto)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should reject circular dependencies', async () => {
+      const dto: CreateDagWorkflowDto = {
+        nodes: [
+          {
+            jobId: 'a',
+            type: 'data-processing',
+            payload: {},
+            dependsOn: [{ jobId: 'b', condition: DependencyCondition.ON_SUCCESS }],
+          },
+          {
+            jobId: 'b',
+            type: 'data-processing',
+            payload: {},
+            dependsOn: [{ jobId: 'a', condition: DependencyCondition.ON_SUCCESS }],
+          },
+        ],
+      };
+
+      await expect(service.submitWorkflow(dto)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should enqueue multiple root nodes in parallel', async () => {
+      const dto: CreateDagWorkflowDto = {
+        nodes: [
+          { jobId: 'root-a', type: 'data-processing', payload: {} },
+          { jobId: 'root-b', type: 'ai-computation', payload: {} },
+          {
+            jobId: 'join',
+            type: 'report-generation',
+            payload: {},
+            dependsOn: [
+              { jobId: 'root-a', condition: DependencyCondition.ON_SUCCESS },
+              { jobId: 'root-b', condition: DependencyCondition.ON_SUCCESS },
+            ],
+          },
+        ],
+      };
+
+      await service.submitWorkflow(dto);
+
+      // Both root nodes should be enqueued
+      expect(mockQueueService.addComputeJob).toHaveBeenCalledTimes(2);
+    });
+
+    it('should pass upstream results in dagContext', async () => {
+      const dto: CreateDagWorkflowDto = {
+        nodes: [
+          { jobId: 'step1', type: 'data-processing', payload: { x: 1 } },
+          {
+            jobId: 'step2',
+            type: 'data-processing',
+            payload: { y: 2 },
+            dependsOn: [{ jobId: 'step1', condition: DependencyCondition.ON_SUCCESS }],
+          },
+        ],
+      };
+
+      const workflow = await service.submitWorkflow(dto);
+
+      // Simulate step1 completing
+      eventEmitter.emit('dag.job.completed', {
+        workflowId: workflow.workflowId,
+        nodeId: 'step1',
+        result: { output: 42 },
+      });
+
+      // Give the async handler a tick to run
+      await new Promise((r) => setTimeout(r, 50));
+
+      // step2 should now be enqueued with upstream results
+      expect(mockQueueService.addComputeJob).toHaveBeenCalledTimes(2);
+      const step2Call = mockQueueService.addComputeJob.mock.calls[1][0];
+      expect(step2Call.metadata.dagContext.upstreamResults).toEqual({
+        step1: { output: 42 },
+      });
+    });
+  });
+
+  describe('validateWorkflow', () => {
+    it('should return valid for a correct DAG', () => {
+      const dto: CreateDagWorkflowDto = {
+        nodes: [
+          { jobId: 'a', type: 'data-processing', payload: {} },
+          {
+            jobId: 'b',
+            type: 'data-processing',
+            payload: {},
+            dependsOn: [{ jobId: 'a', condition: DependencyCondition.ON_SUCCESS }],
+          },
+        ],
+      };
+
+      const result = service.validateWorkflow(dto);
+
+      expect(result.valid).toBe(true);
+      expect(result.topologicalOrder).toEqual(['a', 'b']);
+    });
+
+    it('should return invalid for a cyclic graph', () => {
+      const dto: CreateDagWorkflowDto = {
+        nodes: [
+          {
+            jobId: 'a',
+            type: 'data-processing',
+            payload: {},
+            dependsOn: [{ jobId: 'b' }],
+          },
+          {
+            jobId: 'b',
+            type: 'data-processing',
+            payload: {},
+            dependsOn: [{ jobId: 'a' }],
+          },
+        ],
+      };
+
+      const result = service.validateWorkflow(dto);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getWorkflow', () => {
+    it('should return a submitted workflow', async () => {
+      const dto: CreateDagWorkflowDto = {
+        name: 'My Workflow',
+        nodes: [{ jobId: 'solo', type: 'data-processing', payload: {} }],
+      };
+
+      const created = await service.submitWorkflow(dto);
+      const fetched = service.getWorkflow(created.workflowId);
+
+      expect(fetched.workflowId).toBe(created.workflowId);
+      expect(fetched.name).toBe('My Workflow');
+    });
+
+    it('should throw NotFoundException for unknown ID', () => {
+      expect(() => service.getWorkflow('nonexistent')).toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('cancelWorkflow', () => {
+    it('should cancel a running workflow', async () => {
+      const dto: CreateDagWorkflowDto = {
+        nodes: [
+          { jobId: 'a', type: 'data-processing', payload: {} },
+          {
+            jobId: 'b',
+            type: 'data-processing',
+            payload: {},
+            dependsOn: [{ jobId: 'a', condition: DependencyCondition.ON_SUCCESS }],
+          },
+        ],
+      };
+
+      const workflow = await service.submitWorkflow(dto);
+      const cancelled = await service.cancelWorkflow(workflow.workflowId);
+
+      expect(cancelled.status).toBe(DagWorkflowStatus.CANCELLED);
+      expect(cancelled.completedAt).toBeDefined();
+
+      // The pending node 'b' should be CANCELLED
+      const nodeB = cancelled.nodes.get('b');
+      expect(nodeB.status).toBe(DagNodeStatus.CANCELLED);
+    });
+
+    it('should throw when cancelling an already completed workflow', async () => {
+      const dto: CreateDagWorkflowDto = {
+        nodes: [{ jobId: 'only', type: 'data-processing', payload: {} }],
+      };
+
+      const workflow = await service.submitWorkflow(dto);
+
+      // Simulate completion
+      eventEmitter.emit('dag.job.completed', {
+        workflowId: workflow.workflowId,
+        nodeId: 'only',
+        result: {},
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      await expect(
+        service.cancelWorkflow(workflow.workflowId),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('listWorkflows', () => {
+    it('should list all submitted workflows', async () => {
+      await service.submitWorkflow({
+        name: 'WF-1',
+        nodes: [{ jobId: 'a', type: 'data-processing', payload: {} }],
+      });
+      await service.submitWorkflow({
+        name: 'WF-2',
+        nodes: [{ jobId: 'b', type: 'data-processing', payload: {} }],
+      });
+
+      const list = service.listWorkflows();
+
+      expect(list).toHaveLength(2);
+      expect(list.map((w) => w.name)).toContain('WF-1');
+      expect(list.map((w) => w.name)).toContain('WF-2');
+    });
+  });
+
+  describe('resolveReadyJobs', () => {
+    it('should resolve root nodes as ready', async () => {
+      const dto: CreateDagWorkflowDto = {
+        nodes: [
+          { jobId: 'a', type: 'data-processing', payload: {} },
+          {
+            jobId: 'b',
+            type: 'data-processing',
+            payload: {},
+            dependsOn: [{ jobId: 'a', condition: DependencyCondition.ON_SUCCESS }],
+          },
+        ],
+      };
+
+      const workflow = await service.submitWorkflow(dto);
+
+      // After submission, 'a' is already queued/running. Reset it to PENDING for testing.
+      workflow.nodes.get('a').status = DagNodeStatus.PENDING;
+
+      const ready = service.resolveReadyJobs(workflow);
+
+      expect(ready).toContain('a');
+      expect(ready).not.toContain('b');
+    });
+  });
+
+  describe('workflow advancement via events', () => {
+    it('should advance the workflow when a node completes', async () => {
+      const dto: CreateDagWorkflowDto = {
+        nodes: [
+          { jobId: 'step1', type: 'data-processing', payload: {} },
+          {
+            jobId: 'step2',
+            type: 'data-processing',
+            payload: {},
+            dependsOn: [{ jobId: 'step1', condition: DependencyCondition.ON_SUCCESS }],
+          },
+          {
+            jobId: 'step3',
+            type: 'data-processing',
+            payload: {},
+            dependsOn: [{ jobId: 'step2', condition: DependencyCondition.ON_SUCCESS }],
+          },
+        ],
+      };
+
+      const workflow = await service.submitWorkflow(dto);
+
+      // step1 completes
+      eventEmitter.emit('dag.job.completed', {
+        workflowId: workflow.workflowId,
+        nodeId: 'step1',
+        result: { data: 'from-step1' },
+      });
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(workflow.nodes.get('step1').status).toBe(DagNodeStatus.COMPLETED);
+      // step2 should now be running
+      expect(mockQueueService.addComputeJob).toHaveBeenCalledTimes(2);
+
+      // step2 completes
+      eventEmitter.emit('dag.job.completed', {
+        workflowId: workflow.workflowId,
+        nodeId: 'step2',
+        result: { data: 'from-step2' },
+      });
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(workflow.nodes.get('step2').status).toBe(DagNodeStatus.COMPLETED);
+      // step3 should now be running
+      expect(mockQueueService.addComputeJob).toHaveBeenCalledTimes(3);
+    });
+
+    it('should skip downstream nodes when onSuccess condition is not met', async () => {
+      const dto: CreateDagWorkflowDto = {
+        nodes: [
+          { jobId: 'step1', type: 'data-processing', payload: {} },
+          {
+            jobId: 'step2',
+            type: 'data-processing',
+            payload: {},
+            dependsOn: [{ jobId: 'step1', condition: DependencyCondition.ON_SUCCESS }],
+          },
+        ],
+      };
+
+      const workflow = await service.submitWorkflow(dto);
+
+      // step1 fails
+      eventEmitter.emit('dag.job.failed', {
+        workflowId: workflow.workflowId,
+        nodeId: 'step1',
+        error: 'Something went wrong',
+      });
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(workflow.nodes.get('step1').status).toBe(DagNodeStatus.FAILED);
+      expect(workflow.nodes.get('step2').status).toBe(DagNodeStatus.SKIPPED);
+      expect(workflow.status).toBe(DagWorkflowStatus.FAILED);
+    });
+
+    it('should run onFailure nodes when parent fails', async () => {
+      const dto: CreateDagWorkflowDto = {
+        nodes: [
+          { jobId: 'main', type: 'data-processing', payload: {} },
+          {
+            jobId: 'error-handler',
+            type: 'email-notification',
+            payload: { to: 'admin@example.com' },
+            dependsOn: [{ jobId: 'main', condition: DependencyCondition.ON_FAILURE }],
+          },
+        ],
+      };
+
+      const workflow = await service.submitWorkflow(dto);
+
+      // main fails
+      eventEmitter.emit('dag.job.failed', {
+        workflowId: workflow.workflowId,
+        nodeId: 'main',
+        error: 'Crash',
+      });
+      await new Promise((r) => setTimeout(r, 50));
+
+      // error-handler should have been enqueued
+      expect(mockQueueService.addComputeJob).toHaveBeenCalledTimes(2);
+      const secondCall = mockQueueService.addComputeJob.mock.calls[1][0];
+      expect(secondCall.type).toBe('email-notification');
+    });
+
+    it('should finalize workflow as COMPLETED when all nodes succeed', async () => {
+      const dto: CreateDagWorkflowDto = {
+        nodes: [
+          { jobId: 'only', type: 'data-processing', payload: {} },
+        ],
+      };
+
+      const workflow = await service.submitWorkflow(dto);
+
+      eventEmitter.emit('dag.job.completed', {
+        workflowId: workflow.workflowId,
+        nodeId: 'only',
+        result: { done: true },
+      });
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(workflow.status).toBe(DagWorkflowStatus.COMPLETED);
+      expect(workflow.completedAt).toBeDefined();
+    });
+
+    it('should finalize as PARTIALLY_COMPLETED when some fail and some succeed', async () => {
+      const dto: CreateDagWorkflowDto = {
+        nodes: [
+          { jobId: 'a', type: 'data-processing', payload: {} },
+          { jobId: 'b', type: 'data-processing', payload: {} },
+          {
+            jobId: 'c',
+            type: 'data-processing',
+            payload: {},
+            dependsOn: [{ jobId: 'b', condition: DependencyCondition.ON_SUCCESS }],
+          },
+        ],
+      };
+
+      const workflow = await service.submitWorkflow(dto);
+
+      // 'a' succeeds
+      eventEmitter.emit('dag.job.completed', {
+        workflowId: workflow.workflowId,
+        nodeId: 'a',
+        result: {},
+      });
+      await new Promise((r) => setTimeout(r, 50));
+
+      // 'b' fails → 'c' should be skipped
+      eventEmitter.emit('dag.job.failed', {
+        workflowId: workflow.workflowId,
+        nodeId: 'b',
+        error: 'boom',
+      });
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(workflow.status).toBe(DagWorkflowStatus.PARTIALLY_COMPLETED);
+    });
+  });
+});

--- a/src/compute-job-queue/dag/dag.service.ts
+++ b/src/compute-job-queue/dag/dag.service.ts
@@ -1,0 +1,552 @@
+import {
+  Injectable,
+  Logger,
+  BadRequestException,
+  NotFoundException,
+} from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { QueueService, ComputeJobData } from '../queue.service';
+import { DagValidator } from './dag.validator';
+import {
+  DagDependency,
+  DagJobContext,
+  DagNode,
+  DagNodeStatus,
+  DagValidationResult,
+  DagWorkflow,
+  DagWorkflowStatus,
+  DependencyCondition,
+} from './dag.interfaces';
+import { CreateDagWorkflowDto } from './dag.dto';
+
+/**
+ * Orchestrates DAG-based job workflows.
+ *
+ * Manages the full lifecycle: submission → validation → scheduling →
+ * dependency resolution → completion tracking.
+ *
+ * Workflows are stored in-memory (swap to Redis/DB for production HA).
+ */
+@Injectable()
+export class DagService {
+  private readonly logger = new Logger(DagService.name);
+  private readonly workflows = new Map<string, DagWorkflow>();
+
+  constructor(
+    private readonly queueService: QueueService,
+    private readonly dagValidator: DagValidator,
+    private readonly eventEmitter: EventEmitter2,
+  ) {
+    this.registerEventListeners();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Submit a new DAG workflow.
+   *
+   * Validates the graph structure, persists it, and enqueues all root
+   * nodes (those with no dependencies) immediately.
+   */
+  async submitWorkflow(dto: CreateDagWorkflowDto): Promise<DagWorkflow> {
+    const workflowId = this.generateWorkflowId();
+
+    // Build dependency map for validation.
+    const depMap = new Map<string, DagDependency[]>();
+    const seenIds = new Set<string>();
+
+    for (const node of dto.nodes) {
+      if (seenIds.has(node.jobId)) {
+        throw new BadRequestException(
+          `Duplicate node ID "${node.jobId}" in workflow`,
+        );
+      }
+      seenIds.add(node.jobId);
+
+      const deps: DagDependency[] = (node.dependsOn || []).map((d) => ({
+        jobId: d.jobId,
+        condition: d.condition ?? DependencyCondition.ON_SUCCESS,
+      }));
+      depMap.set(node.jobId, deps);
+    }
+
+    // Validate DAG structure.
+    const validation = this.dagValidator.validate(depMap);
+    if (!validation.valid) {
+      throw new BadRequestException({
+        message: 'Invalid DAG structure',
+        errors: validation.errors,
+      });
+    }
+
+    // Build internal workflow representation.
+    const nodes = new Map<string, DagNode>();
+    const edges = new Map<string, Set<string>>();
+    const reverseEdges = new Map<string, Set<string>>();
+
+    for (const nodeDto of dto.nodes) {
+      const deps: DagDependency[] = (nodeDto.dependsOn || []).map((d) => ({
+        jobId: d.jobId,
+        condition: d.condition ?? DependencyCondition.ON_SUCCESS,
+      }));
+
+      nodes.set(nodeDto.jobId, {
+        jobId: nodeDto.jobId,
+        type: nodeDto.type,
+        payload: nodeDto.payload,
+        userId: nodeDto.userId ?? dto.userId,
+        priority: nodeDto.priority,
+        groupKey: nodeDto.groupKey,
+        metadata: nodeDto.metadata,
+        dependsOn: deps,
+        status: DagNodeStatus.PENDING,
+      });
+
+      edges.set(nodeDto.jobId, new Set());
+      reverseEdges.set(nodeDto.jobId, new Set());
+    }
+
+    // Populate adjacency lists.
+    for (const [nodeId, deps] of depMap) {
+      for (const dep of deps) {
+        edges.get(dep.jobId)?.add(nodeId);
+        reverseEdges.get(nodeId)?.add(dep.jobId);
+      }
+    }
+
+    const workflow: DagWorkflow = {
+      workflowId,
+      name: dto.name,
+      nodes,
+      edges,
+      reverseEdges,
+      status: DagWorkflowStatus.RUNNING,
+      topologicalOrder: validation.topologicalOrder!,
+      createdAt: new Date(),
+      userId: dto.userId,
+      metadata: dto.metadata,
+    };
+
+    this.workflows.set(workflowId, workflow);
+    this.logger.log(
+      `Workflow ${workflowId} created with ${nodes.size} nodes`,
+    );
+
+    // Enqueue root nodes (no dependencies).
+    const readyJobs = this.resolveReadyJobs(workflow);
+    for (const jobId of readyJobs) {
+      await this.enqueueNode(workflow, jobId);
+    }
+
+    return workflow;
+  }
+
+  /**
+   * Validate a DAG structure without submitting it.
+   * Useful for dry-run / pre-flight checks.
+   */
+  validateWorkflow(dto: CreateDagWorkflowDto): DagValidationResult {
+    const depMap = new Map<string, DagDependency[]>();
+    const seenIds = new Set<string>();
+
+    for (const node of dto.nodes) {
+      if (seenIds.has(node.jobId)) {
+        return {
+          valid: false,
+          errors: [`Duplicate node ID "${node.jobId}" in workflow`],
+        };
+      }
+      seenIds.add(node.jobId);
+
+      const deps: DagDependency[] = (node.dependsOn || []).map((d) => ({
+        jobId: d.jobId,
+        condition: d.condition ?? DependencyCondition.ON_SUCCESS,
+      }));
+      depMap.set(node.jobId, deps);
+    }
+
+    return this.dagValidator.validate(depMap);
+  }
+
+  /**
+   * Retrieve a workflow by ID.
+   */
+  getWorkflow(workflowId: string): DagWorkflow {
+    const workflow = this.workflows.get(workflowId);
+    if (!workflow) {
+      throw new NotFoundException(`Workflow "${workflowId}" not found`);
+    }
+    return workflow;
+  }
+
+  /**
+   * Cancel a running workflow.
+   * Nodes that are still PENDING or QUEUED are marked CANCELLED.
+   */
+  async cancelWorkflow(workflowId: string): Promise<DagWorkflow> {
+    const workflow = this.getWorkflow(workflowId);
+
+    if (
+      workflow.status === DagWorkflowStatus.COMPLETED ||
+      workflow.status === DagWorkflowStatus.CANCELLED
+    ) {
+      throw new BadRequestException(
+        `Workflow "${workflowId}" is already ${workflow.status}`,
+      );
+    }
+
+    for (const node of workflow.nodes.values()) {
+      if (
+        node.status === DagNodeStatus.PENDING ||
+        node.status === DagNodeStatus.QUEUED
+      ) {
+        node.status = DagNodeStatus.CANCELLED;
+      }
+    }
+
+    workflow.status = DagWorkflowStatus.CANCELLED;
+    workflow.completedAt = new Date();
+
+    this.logger.log(`Workflow ${workflowId} cancelled`);
+    return workflow;
+  }
+
+  /**
+   * List all workflows (lightweight – returns workflow IDs and statuses).
+   */
+  listWorkflows(): Array<{
+    workflowId: string;
+    name?: string;
+    status: DagWorkflowStatus;
+    nodeCount: number;
+    createdAt: Date;
+  }> {
+    return Array.from(this.workflows.values()).map((wf) => ({
+      workflowId: wf.workflowId,
+      name: wf.name,
+      status: wf.status,
+      nodeCount: wf.nodes.size,
+      createdAt: wf.createdAt,
+    }));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Dependency resolution
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Determine which nodes are ready to execute.
+   *
+   * A node is "ready" when it is PENDING and every upstream dependency
+   * satisfies its declared condition.
+   */
+  resolveReadyJobs(workflow: DagWorkflow): string[] {
+    const ready: string[] = [];
+
+    for (const [nodeId, node] of workflow.nodes) {
+      if (node.status !== DagNodeStatus.PENDING) continue;
+
+      const allSatisfied = node.dependsOn.every((dep) => {
+        const parent = workflow.nodes.get(dep.jobId);
+        if (!parent) return false;
+        return this.isConditionMet(parent, dep.condition);
+      });
+
+      if (allSatisfied) {
+        ready.push(nodeId);
+      }
+    }
+
+    return ready;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Event handling
+  // ---------------------------------------------------------------------------
+
+  private registerEventListeners(): void {
+    this.eventEmitter.on(
+      'dag.job.completed',
+      (event: { workflowId: string; nodeId: string; result: any }) => {
+        this.handleNodeCompletion(
+          event.workflowId,
+          event.nodeId,
+          event.result,
+        ).catch((err) =>
+          this.logger.error(
+            `Error handling completion for ${event.nodeId}: ${err.message}`,
+            err.stack,
+          ),
+        );
+      },
+    );
+
+    this.eventEmitter.on(
+      'dag.job.failed',
+      (event: { workflowId: string; nodeId: string; error: string }) => {
+        this.handleNodeFailure(
+          event.workflowId,
+          event.nodeId,
+          event.error,
+        ).catch((err) =>
+          this.logger.error(
+            `Error handling failure for ${event.nodeId}: ${err.message}`,
+            err.stack,
+          ),
+        );
+      },
+    );
+  }
+
+  /**
+   * Handle a node completing successfully.
+   */
+  private async handleNodeCompletion(
+    workflowId: string,
+    nodeId: string,
+    result: any,
+  ): Promise<void> {
+    const workflow = this.workflows.get(workflowId);
+    if (!workflow) return;
+
+    const node = workflow.nodes.get(nodeId);
+    if (!node) return;
+
+    node.status = DagNodeStatus.COMPLETED;
+    node.result = result;
+
+    this.logger.log(
+      `Node "${nodeId}" in workflow ${workflowId} completed`,
+    );
+
+    await this.advanceWorkflow(workflow);
+  }
+
+  /**
+   * Handle a node failing.
+   */
+  private async handleNodeFailure(
+    workflowId: string,
+    nodeId: string,
+    error: string,
+  ): Promise<void> {
+    const workflow = this.workflows.get(workflowId);
+    if (!workflow) return;
+
+    const node = workflow.nodes.get(nodeId);
+    if (!node) return;
+
+    node.status = DagNodeStatus.FAILED;
+    node.error = error;
+
+    this.logger.warn(
+      `Node "${nodeId}" in workflow ${workflowId} failed: ${error}`,
+    );
+
+    await this.advanceWorkflow(workflow);
+  }
+
+  /**
+   * After a node completes or fails, re-evaluate the DAG and enqueue
+   * any newly-ready downstream nodes. If nothing is left to run,
+   * finalize the workflow.
+   */
+  private async advanceWorkflow(workflow: DagWorkflow): Promise<void> {
+    if (workflow.status === DagWorkflowStatus.CANCELLED) return;
+
+    // Skip nodes whose conditions can never be met.
+    this.skipUnreachableNodes(workflow);
+
+    const readyJobs = this.resolveReadyJobs(workflow);
+
+    for (const jobId of readyJobs) {
+      await this.enqueueNode(workflow, jobId);
+    }
+
+    // Check if the workflow is finished.
+    const allDone = Array.from(workflow.nodes.values()).every(
+      (n) =>
+        n.status === DagNodeStatus.COMPLETED ||
+        n.status === DagNodeStatus.FAILED ||
+        n.status === DagNodeStatus.SKIPPED ||
+        n.status === DagNodeStatus.CANCELLED,
+    );
+
+    if (allDone) {
+      this.finalizeWorkflow(workflow);
+    }
+  }
+
+  /**
+   * Mark PENDING nodes as SKIPPED when their dependency conditions
+   * can never be satisfied (e.g. parent failed but condition is onSuccess
+   * and there are no other paths).
+   */
+  private skipUnreachableNodes(workflow: DagWorkflow): void {
+    let changed = true;
+
+    while (changed) {
+      changed = false;
+
+      for (const [, node] of workflow.nodes) {
+        if (node.status !== DagNodeStatus.PENDING) continue;
+
+        const unreachable = node.dependsOn.some((dep) => {
+          const parent = workflow.nodes.get(dep.jobId);
+          if (!parent) return true;
+
+          // If the parent is in a terminal state and the condition isn't met,
+          // and the condition isn't ALWAYS, this node can never run.
+          const parentTerminal =
+            parent.status === DagNodeStatus.COMPLETED ||
+            parent.status === DagNodeStatus.FAILED ||
+            parent.status === DagNodeStatus.SKIPPED ||
+            parent.status === DagNodeStatus.CANCELLED;
+
+          if (parentTerminal && !this.isConditionMet(parent, dep.condition)) {
+            return true;
+          }
+
+          return false;
+        });
+
+        if (unreachable) {
+          node.status = DagNodeStatus.SKIPPED;
+          changed = true;
+        }
+      }
+    }
+  }
+
+  /**
+   * Determine the final workflow status based on node outcomes.
+   */
+  private finalizeWorkflow(workflow: DagWorkflow): void {
+    const statuses = Array.from(workflow.nodes.values()).map((n) => n.status);
+    const hasFailures = statuses.includes(DagNodeStatus.FAILED);
+    const hasCompleted = statuses.includes(DagNodeStatus.COMPLETED);
+
+    if (hasFailures && hasCompleted) {
+      workflow.status = DagWorkflowStatus.PARTIALLY_COMPLETED;
+    } else if (hasFailures) {
+      workflow.status = DagWorkflowStatus.FAILED;
+    } else {
+      workflow.status = DagWorkflowStatus.COMPLETED;
+    }
+
+    workflow.completedAt = new Date();
+
+    this.logger.log(
+      `Workflow ${workflow.workflowId} finalized as ${workflow.status}`,
+    );
+
+    this.eventEmitter.emit('dag.workflow.completed', {
+      workflowId: workflow.workflowId,
+      status: workflow.status,
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Enqueue a single DAG node into the Bull compute queue.
+   * Attaches upstream results in the job's metadata so the processor
+   * can access them via DagJobContext.
+   */
+  private async enqueueNode(
+    workflow: DagWorkflow,
+    nodeId: string,
+  ): Promise<void> {
+    const node = workflow.nodes.get(nodeId);
+    if (!node) return;
+
+    node.status = DagNodeStatus.QUEUED;
+
+    const upstreamResults: Record<string, any> = {};
+    for (const dep of node.dependsOn) {
+      const parent = workflow.nodes.get(dep.jobId);
+      if (parent?.result !== undefined) {
+        upstreamResults[dep.jobId] = parent.result;
+      }
+    }
+
+    const dagContext: DagJobContext = {
+      workflowId: workflow.workflowId,
+      nodeId,
+      upstreamResults,
+    };
+
+    const jobData: ComputeJobData = {
+      type: node.type,
+      payload: node.payload,
+      userId: node.userId,
+      priority: node.priority,
+      groupKey: node.groupKey,
+      metadata: {
+        ...node.metadata,
+        dagContext,
+      },
+    };
+
+    try {
+      const job = await this.queueService.addComputeJob(jobData);
+      node.queueJobId = String(job.id);
+      node.status = DagNodeStatus.RUNNING;
+
+      this.logger.log(
+        `Node "${nodeId}" enqueued as Bull job ${job.id} in workflow ${workflow.workflowId}`,
+      );
+    } catch (err) {
+      node.status = DagNodeStatus.FAILED;
+      node.error = `Failed to enqueue: ${err.message}`;
+      this.logger.error(
+        `Failed to enqueue node "${nodeId}": ${err.message}`,
+        err.stack,
+      );
+    }
+  }
+
+  /**
+   * Check whether a dependency condition is satisfied by the parent node's
+   * current status.
+   */
+  private isConditionMet(
+    parent: DagNode,
+    condition: DependencyCondition,
+  ): boolean {
+    switch (condition) {
+      case DependencyCondition.ON_SUCCESS:
+        return parent.status === DagNodeStatus.COMPLETED;
+
+      case DependencyCondition.ON_FAILURE:
+        return parent.status === DagNodeStatus.FAILED;
+
+      case DependencyCondition.ON_PARTIAL_SUCCESS:
+        return (
+          parent.status === DagNodeStatus.COMPLETED ||
+          parent.status === DagNodeStatus.FAILED
+        );
+
+      case DependencyCondition.ALWAYS:
+        return (
+          parent.status === DagNodeStatus.COMPLETED ||
+          parent.status === DagNodeStatus.FAILED ||
+          parent.status === DagNodeStatus.SKIPPED ||
+          parent.status === DagNodeStatus.CANCELLED
+        );
+
+      default:
+        return false;
+    }
+  }
+
+  private generateWorkflowId(): string {
+    const ts = Date.now().toString(36);
+    const rand = Math.random().toString(36).substring(2, 8);
+    return `wf-${ts}-${rand}`;
+  }
+}

--- a/src/compute-job-queue/dag/dag.validator.spec.ts
+++ b/src/compute-job-queue/dag/dag.validator.spec.ts
@@ -1,0 +1,200 @@
+import { DagValidator } from './dag.validator';
+import { DagDependency, DependencyCondition } from './dag.interfaces';
+
+describe('DagValidator', () => {
+  let validator: DagValidator;
+
+  beforeEach(() => {
+    validator = new DagValidator();
+  });
+
+  describe('validate', () => {
+    it('should accept a single node with no dependencies', () => {
+      const nodes = new Map<string, DagDependency[]>();
+      nodes.set('job-a', []);
+
+      const result = validator.validate(nodes);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+      expect(result.topologicalOrder).toEqual(['job-a']);
+    });
+
+    it('should accept a simple linear chain A → B → C', () => {
+      const nodes = new Map<string, DagDependency[]>();
+      nodes.set('a', []);
+      nodes.set('b', [{ jobId: 'a', condition: DependencyCondition.ON_SUCCESS }]);
+      nodes.set('c', [{ jobId: 'b', condition: DependencyCondition.ON_SUCCESS }]);
+
+      const result = validator.validate(nodes);
+
+      expect(result.valid).toBe(true);
+      expect(result.topologicalOrder).toBeDefined();
+      const order = result.topologicalOrder!;
+      expect(order.indexOf('a')).toBeLessThan(order.indexOf('b'));
+      expect(order.indexOf('b')).toBeLessThan(order.indexOf('c'));
+    });
+
+    it('should accept a diamond-shaped DAG', () => {
+      //     A
+      //    / \
+      //   B   C
+      //    \ /
+      //     D
+      const nodes = new Map<string, DagDependency[]>();
+      nodes.set('a', []);
+      nodes.set('b', [{ jobId: 'a', condition: DependencyCondition.ON_SUCCESS }]);
+      nodes.set('c', [{ jobId: 'a', condition: DependencyCondition.ON_SUCCESS }]);
+      nodes.set('d', [
+        { jobId: 'b', condition: DependencyCondition.ON_SUCCESS },
+        { jobId: 'c', condition: DependencyCondition.ON_SUCCESS },
+      ]);
+
+      const result = validator.validate(nodes);
+
+      expect(result.valid).toBe(true);
+      const order = result.topologicalOrder!;
+      expect(order.indexOf('a')).toBeLessThan(order.indexOf('b'));
+      expect(order.indexOf('a')).toBeLessThan(order.indexOf('c'));
+      expect(order.indexOf('b')).toBeLessThan(order.indexOf('d'));
+      expect(order.indexOf('c')).toBeLessThan(order.indexOf('d'));
+    });
+
+    it('should accept parallel independent nodes', () => {
+      const nodes = new Map<string, DagDependency[]>();
+      nodes.set('x', []);
+      nodes.set('y', []);
+      nodes.set('z', []);
+
+      const result = validator.validate(nodes);
+
+      expect(result.valid).toBe(true);
+      expect(result.topologicalOrder).toHaveLength(3);
+    });
+
+    it('should reject an empty graph', () => {
+      const nodes = new Map<string, DagDependency[]>();
+
+      const result = validator.validate(nodes);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('DAG must contain at least one node');
+    });
+
+    it('should reject self-dependencies', () => {
+      const nodes = new Map<string, DagDependency[]>();
+      nodes.set('a', [{ jobId: 'a', condition: DependencyCondition.ON_SUCCESS }]);
+
+      const result = validator.validate(nodes);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('self-dependency'))).toBe(true);
+    });
+
+    it('should reject references to unknown nodes', () => {
+      const nodes = new Map<string, DagDependency[]>();
+      nodes.set('a', []);
+      nodes.set('b', [{ jobId: 'ghost', condition: DependencyCondition.ON_SUCCESS }]);
+
+      const result = validator.validate(nodes);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('unknown node "ghost"'))).toBe(true);
+    });
+
+    it('should reject a simple two-node cycle A ↔ B', () => {
+      const nodes = new Map<string, DagDependency[]>();
+      nodes.set('a', [{ jobId: 'b', condition: DependencyCondition.ON_SUCCESS }]);
+      nodes.set('b', [{ jobId: 'a', condition: DependencyCondition.ON_SUCCESS }]);
+
+      const result = validator.validate(nodes);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('Circular dependency'))).toBe(true);
+    });
+
+    it('should reject a three-node cycle A → B → C → A', () => {
+      const nodes = new Map<string, DagDependency[]>();
+      nodes.set('a', [{ jobId: 'c', condition: DependencyCondition.ON_SUCCESS }]);
+      nodes.set('b', [{ jobId: 'a', condition: DependencyCondition.ON_SUCCESS }]);
+      nodes.set('c', [{ jobId: 'b', condition: DependencyCondition.ON_SUCCESS }]);
+
+      const result = validator.validate(nodes);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('Circular dependency'))).toBe(true);
+    });
+
+    it('should reject a cycle embedded in a larger valid graph', () => {
+      // root → a → b → c → a  (cycle among a, b, c)
+      //              → d       (valid leaf)
+      const nodes = new Map<string, DagDependency[]>();
+      nodes.set('root', []);
+      nodes.set('a', [
+        { jobId: 'root', condition: DependencyCondition.ON_SUCCESS },
+        { jobId: 'c', condition: DependencyCondition.ON_SUCCESS },
+      ]);
+      nodes.set('b', [{ jobId: 'a', condition: DependencyCondition.ON_SUCCESS }]);
+      nodes.set('c', [{ jobId: 'b', condition: DependencyCondition.ON_SUCCESS }]);
+      nodes.set('d', [{ jobId: 'b', condition: DependencyCondition.ON_SUCCESS }]);
+
+      const result = validator.validate(nodes);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('Circular dependency'))).toBe(true);
+    });
+
+    it('should handle nodes with multiple dependency conditions', () => {
+      const nodes = new Map<string, DagDependency[]>();
+      nodes.set('extract', []);
+      nodes.set('transform', [{ jobId: 'extract', condition: DependencyCondition.ON_SUCCESS }]);
+      nodes.set('error-handler', [{ jobId: 'extract', condition: DependencyCondition.ON_FAILURE }]);
+      nodes.set('cleanup', [
+        { jobId: 'transform', condition: DependencyCondition.ALWAYS },
+        { jobId: 'error-handler', condition: DependencyCondition.ALWAYS },
+      ]);
+
+      const result = validator.validate(nodes);
+
+      expect(result.valid).toBe(true);
+      const order = result.topologicalOrder!;
+      expect(order.indexOf('extract')).toBeLessThan(order.indexOf('transform'));
+      expect(order.indexOf('extract')).toBeLessThan(order.indexOf('error-handler'));
+      expect(order.indexOf('transform')).toBeLessThan(order.indexOf('cleanup'));
+      expect(order.indexOf('error-handler')).toBeLessThan(order.indexOf('cleanup'));
+    });
+
+    it('should validate a 1000-node graph in under 100ms', () => {
+      const nodes = new Map<string, DagDependency[]>();
+      // Build a wide fan-out/fan-in graph: root → 998 middle nodes → leaf
+      nodes.set('root', []);
+      for (let i = 0; i < 998; i++) {
+        nodes.set(`mid-${i}`, [
+          { jobId: 'root', condition: DependencyCondition.ON_SUCCESS },
+        ]);
+      }
+      nodes.set('leaf', [
+        { jobId: 'mid-0', condition: DependencyCondition.ON_SUCCESS },
+      ]);
+
+      const start = performance.now();
+      const result = validator.validate(nodes);
+      const elapsed = performance.now() - start;
+
+      expect(result.valid).toBe(true);
+      expect(result.topologicalOrder).toHaveLength(1000);
+      expect(elapsed).toBeLessThan(100);
+    });
+
+    it('should report multiple errors at once', () => {
+      const nodes = new Map<string, DagDependency[]>();
+      nodes.set('a', [{ jobId: 'a', condition: DependencyCondition.ON_SUCCESS }]);
+      nodes.set('b', [{ jobId: 'missing', condition: DependencyCondition.ON_SUCCESS }]);
+
+      const result = validator.validate(nodes);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+});

--- a/src/compute-job-queue/dag/dag.validator.ts
+++ b/src/compute-job-queue/dag/dag.validator.ts
@@ -1,0 +1,199 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  DagDependency,
+  DagValidationResult,
+} from './dag.interfaces';
+
+/**
+ * Validates DAG structure at submission time.
+ *
+ * Responsibilities:
+ *  - Detect circular dependencies via DFS-based cycle detection.
+ *  - Verify all dependency references point to existing nodes.
+ *  - Produce a topological ordering (Kahn's algorithm) for scheduling.
+ *  - Enforce structural constraints (no self-loops, non-empty graph).
+ *
+ * Performance target: < 100 ms for 1 000-node graphs.
+ */
+@Injectable()
+export class DagValidator {
+  private readonly logger = new Logger(DagValidator.name);
+
+  /**
+   * Validate a DAG described as a mapping of nodeId → dependencies.
+   *
+   * @param nodes Map of nodeId to its dependency list.
+   * @returns Validation result with errors (if any) and topological order.
+   */
+  validate(
+    nodes: Map<string, DagDependency[]>,
+  ): DagValidationResult {
+    const errors: string[] = [];
+    const nodeIds = new Set(nodes.keys());
+
+    if (nodeIds.size === 0) {
+      return { valid: false, errors: ['DAG must contain at least one node'] };
+    }
+
+    // --- structural checks ---------------------------------------------------
+
+    for (const [nodeId, deps] of nodes) {
+      for (const dep of deps) {
+        if (dep.jobId === nodeId) {
+          errors.push(`Node "${nodeId}" has a self-dependency`);
+        }
+        if (!nodeIds.has(dep.jobId)) {
+          errors.push(
+            `Node "${nodeId}" depends on unknown node "${dep.jobId}"`,
+          );
+        }
+      }
+    }
+
+    if (errors.length > 0) {
+      return { valid: false, errors };
+    }
+
+    // --- cycle detection (DFS with 3-colour marking) -------------------------
+
+    const cycleErrors = this.detectCycles(nodes);
+    if (cycleErrors.length > 0) {
+      return { valid: false, errors: cycleErrors };
+    }
+
+    // --- topological sort (Kahn's algorithm) ---------------------------------
+
+    const topologicalOrder = this.topologicalSort(nodes);
+    if (topologicalOrder.length !== nodeIds.size) {
+      // Should not happen if cycle detection is correct, but guard anyway.
+      return {
+        valid: false,
+        errors: ['Topological sort produced incomplete ordering – possible cycle'],
+      };
+    }
+
+    return { valid: true, errors: [], topologicalOrder };
+  }
+
+  /**
+   * Detect cycles using iterative DFS with a three-colour scheme:
+   *  WHITE (unvisited) → GREY (in current path) → BLACK (fully explored).
+   *
+   * Returns an array of error strings describing each cycle found.
+   */
+  private detectCycles(nodes: Map<string, DagDependency[]>): string[] {
+    const WHITE = 0;
+    const GREY = 1;
+    const BLACK = 2;
+
+    const colour = new Map<string, number>();
+    for (const id of nodes.keys()) {
+      colour.set(id, WHITE);
+    }
+
+    // Build forward adjacency (parent → children) from dependency edges.
+    const children = new Map<string, string[]>();
+    for (const id of nodes.keys()) {
+      children.set(id, []);
+    }
+    for (const [nodeId, deps] of nodes) {
+      for (const dep of deps) {
+        const list = children.get(dep.jobId);
+        if (list) {
+          list.push(nodeId);
+        }
+      }
+    }
+
+    const errors: string[] = [];
+
+    for (const startId of nodes.keys()) {
+      if (colour.get(startId) !== WHITE) continue;
+
+      // Iterative DFS using an explicit stack of [nodeId, childIndex].
+      const stack: Array<[string, number]> = [[startId, 0]];
+      colour.set(startId, GREY);
+
+      while (stack.length > 0) {
+        const top = stack[stack.length - 1];
+        const nodeId = top[0];
+        const childList = children.get(nodeId) || [];
+
+        if (top[1] < childList.length) {
+          const child = childList[top[1]];
+          top[1]++;
+
+          const childColour = colour.get(child);
+          if (childColour === GREY) {
+            // Back-edge detected → cycle.
+            const cyclePath = stack
+              .map(([id]) => id)
+              .slice(stack.findIndex(([id]) => id === child));
+            cyclePath.push(child);
+            errors.push(
+              `Circular dependency detected: ${cyclePath.join(' → ')}`,
+            );
+          } else if (childColour === WHITE) {
+            colour.set(child, GREY);
+            stack.push([child, 0]);
+          }
+        } else {
+          colour.set(nodeId, BLACK);
+          stack.pop();
+        }
+      }
+    }
+
+    return errors;
+  }
+
+  /**
+   * Kahn's algorithm – produces a topological ordering.
+   * Nodes with no dependencies are processed first.
+   */
+  private topologicalSort(
+    nodes: Map<string, DagDependency[]>,
+  ): string[] {
+    // In-degree: how many parents must complete before this node.
+    const inDegree = new Map<string, number>();
+    // Forward adjacency: parent → children.
+    const children = new Map<string, string[]>();
+
+    for (const id of nodes.keys()) {
+      inDegree.set(id, 0);
+      children.set(id, []);
+    }
+
+    for (const [nodeId, deps] of nodes) {
+      inDegree.set(nodeId, deps.length);
+      for (const dep of deps) {
+        children.get(dep.jobId)?.push(nodeId);
+      }
+    }
+
+    // Seed the queue with root nodes (in-degree 0).
+    const queue: string[] = [];
+    for (const [id, degree] of inDegree) {
+      if (degree === 0) {
+        queue.push(id);
+      }
+    }
+
+    const sorted: string[] = [];
+
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      sorted.push(current);
+
+      for (const child of children.get(current) || []) {
+        const newDegree = (inDegree.get(child) || 1) - 1;
+        inDegree.set(child, newDegree);
+        if (newDegree === 0) {
+          queue.push(child);
+        }
+      }
+    }
+
+    return sorted;
+  }
+}


### PR DESCRIPTION
# feat: DAG Job Orchestration

Closes #73

## Summary

Adds a distributed job orchestration system with DAG (Directed Acyclic Graph) support and inter-job dependencies to the compute job queue. Jobs can declare upstream dependencies with conditional execution, enabling multi-stage pipelines, conditional branching, and parallel fan-out/fan-in patterns.

## Changes

### New Files (`src/compute-job-queue/dag/`)

| File | Description |
|------|-------------|
| [dag.interfaces.ts](cci:7://file:///c:/Users/Dell/Documents/stellAIverse-backend/src/compute-job-queue/dag/dag.interfaces.ts:0:0-0:0) | Core types: [DagNode](cci:2://file:///c:/Users/Dell/Documents/stellAIverse-backend/src/compute-job-queue/dag/dag.interfaces.ts:44:0-69:1), [DagDependency](cci:2://file:///c:/Users/Dell/Documents/stellAIverse-backend/src/compute-job-queue/dag/dag.interfaces.ts:38:0-41:1), [DagWorkflow](cci:2://file:///c:/Users/Dell/Documents/stellAIverse-backend/src/compute-job-queue/dag/dag.interfaces.ts:72:0-95:1), status enums, [DagJobContext](cci:2://file:///c:/Users/Dell/Documents/stellAIverse-backend/src/compute-job-queue/dag/dag.interfaces.ts:98:0-105:1), [DagValidationResult](cci:2://file:///c:/Users/Dell/Documents/stellAIverse-backend/src/compute-job-queue/dag/dag.interfaces.ts:108:0-112:1) |
| [dag.validator.ts](cci:7://file:///c:/Users/Dell/Documents/stellAIverse-backend/src/compute-job-queue/dag/dag.validator.ts:0:0-0:0) | DAG validation with cycle detection (DFS 3-color marking) and topological sort (Kahn's algorithm) |
| [dag.dto.ts](cci:7://file:///c:/Users/Dell/Documents/stellAIverse-backend/src/compute-job-queue/dag/dag.dto.ts:0:0-0:0) | Request/response DTOs with `class-validator` decorators and Swagger annotations |
| [dag.service.ts](cci:7://file:///c:/Users/Dell/Documents/stellAIverse-backend/src/compute-job-queue/dag/dag.service.ts:0:0-0:0) | Orchestration engine: workflow submission, dependency resolution, event-driven advancement, skip/cancel logic |
| [dag.controller.ts](cci:7://file:///c:/Users/Dell/Documents/stellAIverse-backend/src/compute-job-queue/dag/dag.controller.ts:0:0-0:0) | REST API at `queue/dag/workflows` — submit, validate, list, get, cancel |
| [dag.module.ts](cci:7://file:///c:/Users/Dell/Documents/stellAIverse-backend/src/compute-job-queue/dag/dag.module.ts:0:0-0:0) | NestJS module with `forwardRef` to [QueueModule](cci:2://file:///c:/Users/Dell/Documents/stellAIverse-backend/src/compute-job-queue/compute-job-queue.module.ts:11:0-71:27) |

### Modified Files

| File | Change |
|------|--------|
| [compute-job-queue.module.ts](cci:7://file:///c:/Users/Dell/Documents/stellAIverse-backend/src/compute-job-queue/compute-job-queue.module.ts:0:0-0:0) | Imported and exported [DagModule](cci:2://file:///c:/Users/Dell/Documents/stellAIverse-backend/src/compute-job-queue/dag/dag.module.ts:13:0-19:25) |
| [compute-job.processor.ts](cci:7://file:///c:/Users/Dell/Documents/stellAIverse-backend/src/compute-job-queue/compute-job.processor.ts:0:0-0:0) | Added `dag.job.completed` and `dag.job.failed` event emissions for DAG-aware jobs |

### Test Files

| File | Tests | Coverage |
|------|-------|----------|
| [dag.validator.spec.ts](cci:7://file:///c:/Users/Dell/Documents/stellAIverse-backend/src/compute-job-queue/dag/dag.validator.spec.ts:0:0-0:0) | 13 tests | Cycle detection, topological order, self-deps, unknown refs, 1000-node perf (<100ms) |
| [dag.service.spec.ts](cci:7://file:///c:/Users/Dell/Documents/stellAIverse-backend/src/compute-job-queue/dag/dag.service.spec.ts:0:0-0:0) | 18 tests | Workflow CRUD, dependency resolution, event-driven advancement, conditional execution |
| [dag.integration.spec.ts](cci:7://file:///c:/Users/Dell/Documents/stellAIverse-backend/src/compute-job-queue/dag/dag.integration.spec.ts:0:0-0:0) | 10 tests | ETL pipeline, conditional branching, fan-out/fan-in, error propagation, cancellation |

## Key Features

- **Dependency conditions**: `onSuccess`, `onFailure`, `onPartialSuccess`, `always`
- **Cycle detection**: DFS with 3-color marking rejects circular dependencies at submission
- **Topological sort**: Kahn's algorithm determines execution order
- **Backpressure**: Jobs remain queued until all upstream dependencies satisfy their conditions
- **Upstream results**: Downstream jobs receive parent results via `dagContext.upstreamResults`
- **Skip logic**: Unreachable nodes are automatically marked `SKIPPED`
- **Workflow lifecycle**: `RUNNING` → `COMPLETED` / `FAILED` / `PARTIALLY_COMPLETED` / `CANCELLED`
- **Performance**: DAG validation < 100ms for 1000-node graphs (tested)

## API Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| `POST` | `/queue/dag/workflows` | Submit a new DAG workflow |
| `POST` | `/queue/dag/workflows/validate` | Dry-run validation |
| `GET` | `/queue/dag/workflows` | List all workflows |
| `GET` | `/queue/dag/workflows/:id` | Get workflow details |
| `POST` | `/queue/dag/workflows/:id/cancel` | Cancel a running workflow |

## Testing

```bash
npx jest --testPathPattern="dag/" --verbose
# 3 suites, 41 tests, 0 failures
```

## Breaking Changes

None. All changes are additive. Existing job queue functionality is unaffected.