### PR TITLE
feat: implement real-time agent telemetry dashboard (WebSocket)

### DIFF
--- a/docs/telemetry-api.md
+++ b/docs/telemetry-api.md
@@ -1,0 +1,62 @@
+# Real-Time Agent Telemetry API Documentation
+
+The Agent Telemetry API provides a WebSocket interface for streaming real-time status, heartbeats, and errors from agents.
+
+## Connection
+
+**Namespace:** `/agent-telemetry`
+**Authentication:** JWT Token required in `auth.token` or `Authorization` header.
+
+```javascript
+const socket = io('http://localhost:3000/agent-telemetry', {
+  auth: { token: 'YOUR_JWT_TOKEN' }
+});
+```
+
+## Subscriptions
+
+### Subscribe to Telemetry
+Subscribe to events with optional filtering.
+
+**Message:** `telemetry:subscribe`
+**Payload:**
+```json
+{
+  "agentId": "string (optional)",
+  "types": ["heartbeat", "status_update", "error", "disconnect"], // optional
+  "severities": ["info", "warning", "error", "critical"] // optional
+}
+```
+
+### Unsubscribe from Telemetry
+**Message:** `telemetry:unsubscribe`
+**Payload:**
+```json
+{
+  "agentId": "string (optional)"
+}
+```
+
+## Incoming Events
+
+### Telemetry Event
+**Event:** `telemetry:event`
+**Payload:**
+```json
+{
+  "agentId": "string",
+  "type": "heartbeat | status_update | error | disconnect",
+  "severity": "info | warning | error | critical",
+  "data": {},
+  "timestamp": "ISO8601 string"
+}
+```
+
+## RBAC Rules
+- **ADMIN**: Can subscribe to all agent telemetry.
+- **OPERATOR**: Can subscribe to all agent telemetry.
+- **USER**: Unauthorized for telemetry access (Dashboard restricted).
+
+## Security
+- All payloads are sanitized to remove sensitive information (API keys, secrets, etc.).
+- Role-based access control is enforced on all subscriptions.

--- a/src/agent/agent.service.ts
+++ b/src/agent/agent.service.ts
@@ -1,8 +1,15 @@
 import { Injectable } from "@nestjs/common";
 import { Agent } from "./entities/agent.entity";
+import { AgentTelemetryService } from "../websocket/agent-telemetry.service";
+import { AgentTelemetryGateway } from "../websocket/agent-telemetry.gateway";
 
 @Injectable()
 export class AgentService {
+  constructor(
+    private readonly telemetryService: AgentTelemetryService,
+    private readonly telemetryGateway: AgentTelemetryGateway,
+  ) {}
+
   private readonly agents: Agent[] = [
     {
       id: "1",
@@ -58,4 +65,37 @@ export class AgentService {
   findOne(id: string): Agent {
     return this.agents.find((agent) => agent.id === id);
   }
+
+  // --- Telemetry Methods ---
+
+  emitHeartbeat(agentId: string, data?: any) {
+    this.telemetryGateway.broadcastTelemetry({
+      agentId,
+      type: "heartbeat",
+      severity: "info",
+      data: data || { status: "active" },
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  updateStatus(agentId: string, status: string, details?: any) {
+    this.telemetryGateway.broadcastTelemetry({
+      agentId,
+      type: "status_update",
+      severity: "info",
+      data: { status, details },
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  reportError(agentId: string, error: string, severity: "warning" | "error" | "critical" = "error") {
+    this.telemetryGateway.broadcastTelemetry({
+      agentId,
+      type: "error",
+      severity,
+      data: { error },
+      timestamp: new Date().toISOString(),
+    });
+  }
 }
+

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,9 +1,13 @@
 import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { User } from "./entities/user.entity";
 import { UserService } from "./user.service";
 import { UserController } from "./user.controller";
 
 @Module({
+  imports: [TypeOrmModule.forFeature([User])],
   controllers: [UserController],
   providers: [UserService],
+  exports: [UserService],
 })
 export class UserModule {}

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,26 +1,35 @@
 import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { User } from "./entities/user.entity";
 import { CreateUserDto } from "./dto/create-user.dto";
 import { UpdateUserDto } from "./dto/update-user.dto";
 
 @Injectable()
 export class UserService {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+  ) {}
+
   create(createUserDto: CreateUserDto) {
-    return "This action adds a new user";
+    return this.userRepository.save(createUserDto);
   }
 
   findAll() {
-    return `This action returns all user`;
+    return this.userRepository.find();
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} user`;
+  findOne(id: string): Promise<User | null> {
+    return this.userRepository.findOne({ where: { id } });
   }
 
-  update(id: number, updateUserDto: UpdateUserDto) {
-    return `This action updates a #${id} user`;
+  async update(id: string, updateUserDto: UpdateUserDto) {
+    await this.userRepository.update(id, updateUserDto);
+    return this.findOne(id);
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} user`;
+  remove(id: string) {
+    return this.userRepository.delete(id);
   }
 }

--- a/src/websocket/agent-telemetry.gateway.ts
+++ b/src/websocket/agent-telemetry.gateway.ts
@@ -1,0 +1,158 @@
+import {
+  WebSocketGateway,
+  WebSocketServer,
+  SubscribeMessage,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  ConnectedSocket,
+  MessageBody,
+} from "@nestjs/websockets";
+import { Server, Socket } from "socket.io";
+import { UseGuards, Logger } from "@nestjs/common";
+import { WebSocketAuthGuard } from "./guards/websocket-auth.guard";
+import { AgentTelemetryService, TelemetryEvent, TelemetryFilter } from "./agent-telemetry.service";
+import { UserRole } from "../user/entities/user.entity";
+import { UserService } from "../user/user.service";
+
+interface AuthenticatedSocket extends Socket {
+  userId?: string;
+  walletAddress?: string;
+  role?: UserRole;
+  filters: Map<string, TelemetryFilter>;
+}
+
+@WebSocketGateway({
+  cors: {
+    origin: process.env.CORS_ORIGIN || "*",
+    credentials: true,
+  },
+  namespace: "/agent-telemetry",
+})
+export class AgentTelemetryGateway
+  implements OnGatewayConnection, OnGatewayDisconnect
+{
+  @WebSocketServer()
+  server: Server;
+
+  private readonly logger = new Logger(AgentTelemetryGateway.name);
+
+  constructor(
+    private readonly telemetryService: AgentTelemetryService,
+    private readonly userService: UserService,
+  ) {}
+
+  async handleConnection(client: AuthenticatedSocket) {
+    this.logger.log(`Client connected to telemetry: ${client.id}`);
+    client.filters = new Map();
+    
+    // Welcome message
+    client.emit("telemetry:welcome", {
+      message: "Connected to Real-Time Agent Telemetry Gateway",
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  async handleDisconnect(client: AuthenticatedSocket) {
+    this.logger.log(`Client disconnected from telemetry: ${client.id}`);
+  }
+
+  @UseGuards(WebSocketAuthGuard)
+  @SubscribeMessage("telemetry:subscribe")
+  async handleSubscribe(
+    @ConnectedSocket() client: AuthenticatedSocket,
+    @MessageBody() filter: TelemetryFilter,
+  ) {
+    try {
+      // Fetch user role for RBAC
+      if (!client.role && client.userId) {
+        const user = await this.userService.findOne(client.userId);
+        if (user) {
+          client.role = user.role;
+        }
+      }
+
+      // Enforce RBAC: only authorized users can subscribe to telemetry
+      const isAuthorized = 
+        client.role === UserRole.ADMIN || 
+        client.role === UserRole.OPERATOR;
+
+      if (!isAuthorized) {
+        this.logger.warn(`Unauthorized telemetry subscription attempt from user ${client.userId} with role ${client.role}`);
+        return {
+          success: false,
+          message: "Unauthorized: Insufficient permissions for telemetry access",
+        };
+      }
+      
+      const subscriptionId = filter.agentId || "all";
+      client.filters.set(subscriptionId, filter);
+      
+      if (filter.agentId) {
+        client.join(`telemetry:agent:${filter.agentId}`);
+      } else {
+        client.join("telemetry:all");
+      }
+
+      this.logger.log(`Client ${client.id} subscribed to telemetry: ${subscriptionId}`);
+
+      return {
+        success: true,
+        message: `Subscribed to telemetry for ${subscriptionId}`,
+      };
+    } catch (error) {
+      this.logger.error(`Subscription error for client ${client.id}:`, error);
+      return {
+        success: false,
+        message: "Failed to subscribe to telemetry",
+      };
+    }
+  }
+
+  @UseGuards(WebSocketAuthGuard)
+  @SubscribeMessage("telemetry:unsubscribe")
+  async handleUnsubscribe(
+    @ConnectedSocket() client: AuthenticatedSocket,
+    @MessageBody() data: { agentId?: string },
+  ) {
+    const subscriptionId = data.agentId || "all";
+    client.filters.delete(subscriptionId);
+    
+    if (data.agentId) {
+      client.leave(`telemetry:agent:${data.agentId}`);
+    } else {
+      client.leave("telemetry:all");
+    }
+
+    this.logger.log(`Client ${client.id} unsubscribed from telemetry: ${subscriptionId}`);
+
+    return {
+      success: true,
+      message: `Unsubscribed from telemetry for ${subscriptionId}`,
+    };
+  }
+
+  /**
+   * Broadcasts a telemetry event to subscribed clients.
+   */
+  broadcastTelemetry(event: TelemetryEvent) {
+    const processedEvent = this.telemetryService.processTelemetry(event);
+    
+    // Broadcast to global subscribers
+    this.server.to("telemetry:all").sockets?.forEach((socket: Socket) => {
+      const authSocket = socket as unknown as AuthenticatedSocket;
+      const globalFilter = authSocket.filters?.get("all");
+      if (globalFilter && this.telemetryService.matchesFilter(processedEvent, globalFilter)) {
+        authSocket.emit("telemetry:event", processedEvent);
+      }
+    });
+
+    // Broadcast to agent-specific subscribers
+    this.server.to(`telemetry:agent:${event.agentId}`).sockets?.forEach((socket: Socket) => {
+      const authSocket = socket as unknown as AuthenticatedSocket;
+      const agentFilter = authSocket.filters?.get(event.agentId);
+      if (agentFilter && this.telemetryService.matchesFilter(processedEvent, agentFilter)) {
+        authSocket.emit("telemetry:event", processedEvent);
+      }
+    });
+  }
+}

--- a/src/websocket/agent-telemetry.service.ts
+++ b/src/websocket/agent-telemetry.service.ts
@@ -1,0 +1,75 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { EventEmitter2 } from "@nestjs/event-emitter";
+
+export interface TelemetryEvent {
+  agentId: string;
+  type: "heartbeat" | "status_update" | "error" | "disconnect";
+  severity: "info" | "warning" | "error" | "critical";
+  data: any;
+  timestamp: string;
+}
+
+export interface TelemetryFilter {
+  agentId?: string;
+  types?: string[];
+  severities?: string[];
+}
+
+@Injectable()
+export class AgentTelemetryService {
+  private readonly logger = new Logger(AgentTelemetryService.name);
+
+  constructor() {}
+
+  /**
+   * Processes a telemetry event and determines which clients should receive it.
+   * This is a placeholder for more complex logic like rate limiting or persistence.
+   */
+  processTelemetry(event: TelemetryEvent): TelemetryEvent {
+    // Strip sensitive information if any
+    const sanitizedData = this.sanitizeData(event.data);
+    
+    return {
+      ...event,
+      data: sanitizedData,
+      timestamp: event.timestamp || new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Sanitizes telemetry data to ensure no PII or sensitive info is leaked.
+   */
+  private sanitizeData(data: any): any {
+    if (!data) return data;
+    
+    const sensitiveKeys = ["apiKey", "secret", "password", "token", "privateKey", "email"];
+    const sanitized = { ...data };
+
+    for (const key of sensitiveKeys) {
+      if (key in sanitized) {
+        sanitized[key] = "[REDACTED]";
+      }
+    }
+
+    return sanitized;
+  }
+
+  /**
+   * Checks if an event matches the client's filter criteria.
+   */
+  matchesFilter(event: TelemetryEvent, filter: TelemetryFilter): boolean {
+    if (filter.agentId && filter.agentId !== event.agentId) {
+      return false;
+    }
+
+    if (filter.types && filter.types.length > 0 && !filter.types.includes(event.type)) {
+      return false;
+    }
+
+    if (filter.severities && filter.severities.length > 0 && !filter.severities.includes(event.severity)) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/src/websocket/websocket.module.ts
+++ b/src/websocket/websocket.module.ts
@@ -1,18 +1,24 @@
 import { Module } from "@nestjs/common";
+import { UserModule } from "../user/user.module";
 import { AgentEventsGateway } from "./gateways/agent-events.gateway";
 import { WebSocketAuthGuard } from "./guards/websocket-auth.guard";
 import { AgentStatusService } from "./services/agent-status.service";
 import { HeartbeatService } from "./services/heartbeat.service";
 import { SubscriptionService } from "./services/subscription.service";
+import { AgentTelemetryGateway } from "./agent-telemetry.gateway";
+import { AgentTelemetryService } from "./agent-telemetry.service";
 
 @Module({
+  imports: [UserModule],
   providers: [
     AgentEventsGateway,
     WebSocketAuthGuard,
     AgentStatusService,
     HeartbeatService,
     SubscriptionService,
+    AgentTelemetryGateway,
+    AgentTelemetryService,
   ],
-  exports: [AgentEventsGateway, AgentStatusService],
+  exports: [AgentEventsGateway, AgentStatusService, AgentTelemetryService],
 })
 export class WebSocketModule {}

--- a/test/websocket/agent-telemetry.e2e-spec.ts
+++ b/test/websocket/agent-telemetry.e2e-spec.ts
@@ -1,0 +1,150 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+const io = require('socket.io-client');
+import { JwtModule, JwtService } from '@nestjs/jwt';
+import { WebSocketModule } from '../../src/websocket/websocket.module';
+import { AgentTelemetryGateway } from '../../src/websocket/agent-telemetry.gateway';
+import { UserRole } from '../../src/user/entities/user.entity';
+import { UserService } from '../../src/user/user.service';
+
+type Socket = ReturnType<typeof io>;
+
+describe('Agent Telemetry WebSocket (E2E)', () => {
+  let app: INestApplication;
+  let gateway: AgentTelemetryGateway;
+  let userService: UserService;
+  let jwtService: JwtService;
+  let port: number;
+
+  const mockUser = {
+    id: 'test-user-id',
+    role: UserRole.OPERATOR,
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        JwtModule.register({ secret: 'test-secret', signOptions: { expiresIn: '24h' } }),
+        WebSocketModule,
+      ],
+    })
+    .overrideProvider(UserService)
+    .useValue({
+      findOne: jest.fn().mockResolvedValue(mockUser),
+    })
+    .compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    await app.listen(0);
+    const server: any = app.getHttpServer();
+    port = server.address().port;
+
+    gateway = moduleFixture.get<AgentTelemetryGateway>(AgentTelemetryGateway);
+    userService = moduleFixture.get<UserService>(UserService);
+    jwtService = moduleFixture.get<JwtService>(JwtService);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const createSocket = (userId: string): Socket => {
+    const token = jwtService.sign({ userId, walletAddress: '0xtest' });
+    return io(`http://localhost:${port}/agent-telemetry`, {
+      auth: { token },
+      transports: ['websocket'],
+    });
+  };
+
+  it('should connect and receive welcome message', (done) => {
+    const socket = createSocket('test-user-id');
+    socket.on('telemetry:welcome', (data: any) => {
+      expect(data.message).toContain('Connected');
+      socket.disconnect();
+      done();
+    });
+  });
+
+  it('should subscribe and receive telemetry events', (done) => {
+    const socket = createSocket('test-user-id');
+    
+    socket.on('connect', () => {
+      socket.emit('telemetry:subscribe', { agentId: 'agent-1' }, (res: any) => {
+        expect(res.success).toBe(true);
+        
+        // Simulating an event from the backend
+        gateway.broadcastTelemetry({
+          agentId: 'agent-1',
+          type: 'heartbeat',
+          severity: 'info',
+          data: { status: 'ok' },
+          timestamp: new Date().toISOString(),
+        });
+      });
+    });
+
+    socket.on('telemetry:event', (event: any) => {
+      expect(event.agentId).toBe('agent-1');
+      expect(event.type).toBe('heartbeat');
+      socket.disconnect();
+      done();
+    });
+  });
+
+  it('should filter telemetry events by type', (done) => {
+    const socket = createSocket('test-user-id');
+    
+    socket.on('connect', () => {
+      socket.emit('telemetry:subscribe', { agentId: 'agent-1', types: ['error'] }, (res: any) => {
+        expect(res.success).toBe(true);
+        
+        // This should NOT be received
+        gateway.broadcastTelemetry({
+          agentId: 'agent-1',
+          type: 'heartbeat',
+          severity: 'info',
+          data: { status: 'ok' },
+          timestamp: new Date().toISOString(),
+        });
+
+        // This SHOULD be received
+        setTimeout(() => {
+          gateway.broadcastTelemetry({
+            agentId: 'agent-1',
+            type: 'error',
+            severity: 'error',
+            data: { error: 'Test error' },
+            timestamp: new Date().toISOString(),
+          });
+        }, 100);
+      });
+    });
+
+    socket.on('telemetry:event', (event: any) => {
+      expect(event.type).toBe('error');
+      socket.disconnect();
+      done();
+    });
+  });
+
+  it('should block unauthorized users (RBAC)', (done) => {
+    // Override user service to return a normal USER
+    (userService.findOne as jest.Mock).mockResolvedValueOnce({
+      id: 'normal-user',
+      role: UserRole.USER,
+    });
+
+    const socket = createSocket('normal-user');
+    
+    socket.on('connect', () => {
+      socket.emit('telemetry:subscribe', { agentId: 'agent-1' }, (res: any) => {
+        expect(res.success).toBe(false);
+        expect(res.message).toContain('Unauthorized');
+        socket.disconnect();
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
closes #127 

Implemented a dedicated WebSocket gateway for agent telemetry (/agent-telemetry) that streams heartbeats, status updates, and errors.

Created AgentTelemetryService for sanitization and event filtering.
Created AgentTelemetryGateway with RBAC (restricted to ADMIN and OPERATOR).
Integrated telemetry triggers into AgentService.
Added developer documentation in docs/telemetry-api.md.
Added E2E tests in test/websocket/agent-telemetry.e2e-spec.ts.