### PR TITLE
feat: make PortfolioModule self-contained with domain exceptions

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -32,15 +32,6 @@ import { AgentEvent } from "./audit/entities/agent-event.entity";
 import { ComputeResult } from "./audit/entities/compute-result.entity";
 import { ProvenanceRecord } from "./audit/entities/provenance-record.entity";
 
-// Portfolio entities
-import { Portfolio } from "./portfolio/entities/portfolio.entity";
-import { PortfolioAsset } from "./portfolio/entities/portfolio-asset.entity";
-import { RiskProfile } from "./portfolio/entities/risk-profile.entity";
-import { OptimizationHistory } from "./portfolio/entities/optimization-history.entity";
-import { RebalancingEvent } from "./portfolio/entities/rebalancing-event.entity";
-import { PerformanceMetric } from "./portfolio/entities/performance-metric.entity";
-import { BacktestResult } from "./portfolio/entities/backtest-result.entity";
-
 // DeFi entities
 import { DeFiPosition } from "./defi/entities/defi-position.entity";
 import { DeFiYieldRecord } from "./defi/entities/defi-yield-record.entity";
@@ -90,13 +81,6 @@ import { SubmissionVerifierService } from "./oracle/submission-verifier.service"
             AgentEvent,
             ComputeResult,
             ProvenanceRecord,
-            Portfolio,
-            PortfolioAsset,
-            RiskProfile,
-            OptimizationHistory,
-            RebalancingEvent,
-            PerformanceMetric,
-            BacktestResult,
             DeFiPosition,
             DeFiYieldRecord,
             DeFiTransaction,

--- a/src/common/guard/portfolio-owner.guard.ts
+++ b/src/common/guard/portfolio-owner.guard.ts
@@ -7,13 +7,8 @@ import {
 } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
-import { Portfolio } from "../entities/portfolio.entity";
+import { Portfolio } from "../../portfolio/entities/portfolio.entity";
 
-/**
- * Guard that verifies the authenticated user owns the portfolio identified
- * by the :id or :portfolioId route parameter.
- * Prevents IDOR attacks on portfolio endpoints.
- */
 @Injectable()
 export class PortfolioOwnerGuard implements CanActivate {
   constructor(

--- a/src/config/typeorm.config.ts
+++ b/src/config/typeorm.config.ts
@@ -8,13 +8,6 @@ import { AgentEvent } from "../audit/entities/agent-event.entity";
 import { OracleSubmission } from "../audit/entities/oracle-submission.entity";
 import { ComputeResult } from "../audit/entities/compute-result.entity";
 import { ProvenanceRecord } from "../audit/entities/provenance-record.entity";
-import { Portfolio } from "../portfolio/entities/portfolio.entity";
-import { PortfolioAsset } from "../portfolio/entities/portfolio-asset.entity";
-import { RiskProfile } from "../portfolio/entities/risk-profile.entity";
-import { OptimizationHistory } from "../portfolio/entities/optimization-history.entity";
-import { RebalancingEvent } from "../portfolio/entities/rebalancing-event.entity";
-import { PerformanceMetric } from "../portfolio/entities/performance-metric.entity";
-import { BacktestResult } from "../portfolio/entities/backtest-result.entity";
 import { DeFiPosition } from "../defi/entities/defi-position.entity";
 import { DeFiYieldRecord } from "../defi/entities/defi-yield-record.entity";
 import { DeFiTransaction } from "../defi/entities/defi-transaction.entity";
@@ -38,13 +31,6 @@ export default new DataSource({
     OracleSubmission,
     ComputeResult,
     ProvenanceRecord,
-    Portfolio,
-    PortfolioAsset,
-    RiskProfile,
-    OptimizationHistory,
-    RebalancingEvent,
-    PerformanceMetric,
-    BacktestResult,
     DeFiPosition,
     DeFiYieldRecord,
     DeFiTransaction,

--- a/src/portfolio/exceptions/portfolio.exceptions.ts
+++ b/src/portfolio/exceptions/portfolio.exceptions.ts
@@ -1,0 +1,19 @@
+import { BadRequestException, NotFoundException } from "@nestjs/common";
+
+export class PortfolioNotFoundException extends NotFoundException {
+  constructor(portfolioId: string) {
+    super(`Portfolio not found: ${portfolioId}`);
+  }
+}
+
+export class InsufficientBalanceException extends BadRequestException {
+  constructor(asset: string) {
+    super(`Insufficient balance for asset ${asset}`);
+  }
+}
+
+export class OptimizationFailedException extends BadRequestException {
+  constructor(message = "Portfolio optimization failed") {
+    super(message);
+  }
+}

--- a/src/portfolio/portfolio.controller.ts
+++ b/src/portfolio/portfolio.controller.ts
@@ -21,7 +21,7 @@ import { RebalancingService } from "./services/rebalancing.service";
 import { PerformanceAnalyticsService } from "./services/performance-analytics.service";
 import { BacktestingService } from "./services/backtesting.service";
 import { MLPredictionService } from "./services/ml-prediction.service";
-import { PortfolioOwnerGuard } from "./guards/portfolio-owner.guard";
+import { PortfolioOwnerGuard } from "src/common/guard/portfolio-owner.guard";
 import { CreatePortfolioDto, UpdatePortfolioDto } from "./dto/portfolio.dto";
 import { AddAssetToPortfolioDto } from "./dto/portfolio-asset.dto";
 import { ApproveOptimizationDto, CreateOptimizationDto } from "./dto/optimization.dto";

--- a/src/portfolio/portfolio.module.ts
+++ b/src/portfolio/portfolio.module.ts
@@ -20,7 +20,7 @@ import { MLPredictionService } from "./services/ml-prediction.service";
 
 // Controllers
 import { PortfolioController } from "./portfolio.controller";
-import { PortfolioOwnerGuard } from "./guards/portfolio-owner.guard";
+import { PortfolioOwnerGuard } from "../common/guard/portfolio-owner.guard";
 
 @Module({
   imports: [

--- a/src/portfolio/services/portfolio.service.ts
+++ b/src/portfolio/services/portfolio.service.ts
@@ -1,4 +1,8 @@
 import { Injectable, Logger, BadRequestException } from "@nestjs/common";
+import {
+  OptimizationFailedException,
+  PortfolioNotFoundException,
+} from "../exceptions/portfolio.exceptions";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import { Portfolio } from "../entities/portfolio.entity";
@@ -59,7 +63,7 @@ export class PortfolioService {
     });
 
     if (!portfolio) {
-      throw new BadRequestException("Portfolio not found");
+      throw new PortfolioNotFoundException(portfolioId);
     }
 
     return portfolio;
@@ -323,7 +327,7 @@ export class PortfolioService {
       result.status = OptimizationStatus.FAILED;
       result.errorMessage = error.message;
       await this.optimizationRepository.save(result);
-      throw error;
+      throw new OptimizationFailedException(error.message);
     }
   }
 

--- a/src/portfolio/services/trading-transaction.service.ts
+++ b/src/portfolio/services/trading-transaction.service.ts
@@ -2,8 +2,11 @@ import {
   Injectable,
   Logger,
   ConflictException,
-  BadRequestException,
 } from "@nestjs/common";
+import {
+  InsufficientBalanceException,
+  PortfolioNotFoundException,
+} from "../exceptions/portfolio.exceptions";
 import { DataSource, EntityManager } from "typeorm";
 import BigNumber from "bignumber.js";
 import { Portfolio } from "../entities/portfolio.entity";
@@ -61,9 +64,7 @@ export class TradingTransactionService {
           .getOne();
 
         if (!portfolio) {
-          throw new BadRequestException(
-            "Portfolio not found or access denied",
-          );
+          throw new PortfolioNotFoundException(op.portfolioId);
         }
 
         // Find or create asset within the same transaction
@@ -86,7 +87,7 @@ export class TradingTransactionService {
 
         // Validate quantity
         if (op.quantity < 0 && Math.abs(op.quantity) > asset.quantity) {
-          throw new BadRequestException("Insufficient asset quantity");
+          throw new InsufficientBalanceException(op.ticker);
         }
 
         const bnQuantity = new BigNumber(op.quantity);
@@ -94,7 +95,7 @@ export class TradingTransactionService {
         const bnCurrentQty = new BigNumber(asset.quantity);
 
         if (bnQuantity.isNegative() && bnQuantity.abs().isGreaterThan(bnCurrentQty)) {
-          throw new BadRequestException("Insufficient asset quantity");
+          throw new InsufficientBalanceException(op.ticker);
         }
 
         const newQty = bnCurrentQty.plus(bnQuantity);


### PR DESCRIPTION
closes #299 

## Summary

Refactor the portfolio module so it is self-contained.

### Changes
- Moved portfolio owner guard into `src/common/guard/portfolio-owner.guard.ts`
- Removed redundant `src/portfolio/guards/portfolio-owner.guard.ts`
- Kept portfolio entities inside `PortfolioModule` via `TypeOrmModule.forFeature([...])`
- Removed portfolio entities from global TypeORM config in `src/app.module.ts` and `src/config/typeorm.config.ts`
- Added domain exceptions in `src/portfolio/exceptions/portfolio.exceptions.ts`
- Switched portfolio service error handling to use domain exceptions
- Verified DTOs already use `class-validator`

### Validation
- `npm run build` passes
- `npx jest --runInBand --rootDir . test/portfolio/portfolio.service.spec.ts --passWithNoTests` passes (8 tests)