### PR TITLE
feat(portfolio): Implement Portfolio Service - CRUD Operations (#316)

### DIFF
--- a/src/portfolio/dto/portfolio.dto.ts
+++ b/src/portfolio/dto/portfolio.dto.ts
@@ -4,11 +4,20 @@ import {
   IsEnum,
   IsNumber,
   IsBoolean,
-  IsJSON,
+  IsObject,
+  IsInt,
+  Min,
+  Max,
+  Length,
 } from "class-validator";
-import { PortfolioStatus } from "../entities/portfolio.entity";
+import { Type } from "class-transformer";
+import { PortfolioStatus, PortfolioType } from "../entities/portfolio.entity";
+
 export class CreatePortfolioDto {
   @IsString()
+  @Length(3, 100, {
+    message: "Portfolio name must be between 3 and 100 characters",
+  })
   name: string;
 
   @IsOptional()
@@ -16,11 +25,19 @@ export class CreatePortfolioDto {
   description?: string;
 
   @IsOptional()
+  @IsEnum(PortfolioType)
+  type?: PortfolioType;
+
+  @IsOptional()
   @IsNumber()
   totalValue?: number;
 
   @IsOptional()
-  @IsJSON()
+  @IsObject()
+  initialAllocation?: Record<string, number>;
+
+  @IsOptional()
+  @IsObject()
   metadata?: Record<string, any>;
 
   @IsOptional()
@@ -39,6 +56,9 @@ export class CreatePortfolioDto {
 export class UpdatePortfolioDto {
   @IsOptional()
   @IsString()
+  @Length(3, 100, {
+    message: "Portfolio name must be between 3 and 100 characters",
+  })
   name?: string;
 
   @IsOptional()
@@ -48,6 +68,14 @@ export class UpdatePortfolioDto {
   @IsOptional()
   @IsEnum(PortfolioStatus)
   status?: PortfolioStatus;
+
+  @IsOptional()
+  @IsEnum(PortfolioType)
+  type?: PortfolioType;
+
+  @IsOptional()
+  @IsObject()
+  targetAllocation?: Record<string, number>;
 
   @IsOptional()
   @IsBoolean()
@@ -62,8 +90,43 @@ export class UpdatePortfolioDto {
   rebalanceThreshold?: number;
 
   @IsOptional()
-  @IsJSON()
+  @IsObject()
   metadata?: Record<string, any>;
+}
+
+export class QueryPortfolioDto {
+  @IsOptional()
+  @IsEnum(PortfolioStatus)
+  status?: PortfolioStatus;
+
+  @IsOptional()
+  @IsEnum(PortfolioType)
+  type?: PortfolioType;
+
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}
+
+export class PaginatedPortfoliosDto {
+  data: PortfolioResponseDto[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
 }
 
 export class PortfolioResponseDto {
@@ -71,9 +134,11 @@ export class PortfolioResponseDto {
   name: string;
   description?: string;
   status: PortfolioStatus;
+  type: PortfolioType;
   totalValue: number;
   currentAllocation: Record<string, number>;
   targetAllocation?: Record<string, number>;
+  initialAllocation?: Record<string, number>;
   autoRebalanceEnabled: boolean;
   rebalanceFrequency?: string;
   rebalanceThreshold: number;

--- a/src/portfolio/entities/portfolio.entity.ts
+++ b/src/portfolio/entities/portfolio.entity.ts
@@ -4,6 +4,7 @@ import {
   Column,
   CreateDateColumn,
   UpdateDateColumn,
+  DeleteDateColumn,
   Index,
   ManyToOne,
   OneToMany,
@@ -19,6 +20,12 @@ export enum PortfolioStatus {
   ACTIVE = "active",
   INACTIVE = "inactive",
   ARCHIVED = "archived",
+}
+
+export enum PortfolioType {
+  BALANCED = "balanced",
+  AGGRESSIVE = "aggressive",
+  CONSERVATIVE = "conservative",
 }
 
 @Entity("portfolios")
@@ -39,6 +46,17 @@ export class Portfolio {
     default: PortfolioStatus.ACTIVE,
   })
   status: PortfolioStatus;
+
+  @Column({
+    type: "enum",
+    enum: PortfolioType,
+    default: PortfolioType.BALANCED,
+  })
+  type: PortfolioType;
+
+  // Initial allocation captured at creation time
+  @Column({ type: "jsonb", nullable: true })
+  initialAllocation: Record<string, number>;
 
   // Total portfolio value
   @Column({ type: "decimal", precision: 18, scale: 2, default: 0 })
@@ -74,6 +92,10 @@ export class Portfolio {
 
   @Column({ nullable: true })
   lastRebalanceDate: Date;
+
+  // Soft-delete timestamp; set when a portfolio is archived/deleted
+  @DeleteDateColumn()
+  deletedAt: Date;
 
   // Relations
   @ManyToOne(() => User, { onDelete: "CASCADE" })

--- a/src/portfolio/exceptions/portfolio.exceptions.ts
+++ b/src/portfolio/exceptions/portfolio.exceptions.ts
@@ -1,4 +1,8 @@
-import { BadRequestException, NotFoundException } from "@nestjs/common";
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from "@nestjs/common";
 
 export class PortfolioNotFoundException extends NotFoundException {
   constructor(portfolioId: string) {
@@ -14,6 +18,18 @@ export class InsufficientBalanceException extends BadRequestException {
 
 export class OptimizationFailedException extends BadRequestException {
   constructor(message = "Portfolio optimization failed") {
+    super(message);
+  }
+}
+
+export class DuplicatePortfolioNameException extends ConflictException {
+  constructor(name: string) {
+    super(`A portfolio with the name "${name}" already exists`);
+  }
+}
+
+export class InvalidPortfolioException extends BadRequestException {
+  constructor(message: string) {
     super(message);
   }
 }

--- a/src/portfolio/portfolio.controller.ts
+++ b/src/portfolio/portfolio.controller.ts
@@ -22,7 +22,11 @@ import { PerformanceAnalyticsService } from "./services/performance-analytics.se
 import { BacktestingService } from "./services/backtesting.service";
 import { MLPredictionService } from "./services/ml-prediction.service";
 import { PortfolioOwnerGuard } from "src/common/guard/portfolio-owner.guard";
-import { CreatePortfolioDto, UpdatePortfolioDto } from "./dto/portfolio.dto";
+import {
+  CreatePortfolioDto,
+  UpdatePortfolioDto,
+  QueryPortfolioDto,
+} from "./dto/portfolio.dto";
 import { AddAssetToPortfolioDto } from "./dto/portfolio-asset.dto";
 import {
   ApproveOptimizationDto,
@@ -58,9 +62,14 @@ export class PortfolioController {
   }
 
   @Get("portfolios")
-  @ApiOperation({ summary: "Get all portfolios for user" })
-  async getUserPortfolios(@Request() req: any) {
-    return this.portfolioService.getUserPortfolios(req.user.id);
+  @ApiOperation({
+    summary: "List portfolios for user with pagination and filtering",
+  })
+  async getUserPortfolios(
+    @Request() req: any,
+    @Query() query: QueryPortfolioDto,
+  ) {
+    return this.portfolioService.listPortfolios(req.user.id, query);
   }
 
   @Get("portfolios/:id")
@@ -80,9 +89,16 @@ export class PortfolioController {
     return this.portfolioService.updatePortfolio(portfolioId, dto);
   }
 
+  @Post("portfolios/:id/archive")
+  @ApiOperation({ summary: "Archive portfolio (soft delete via status)" })
+  @UseGuards(PortfolioOwnerGuard)
+  async archivePortfolio(@Param("id") portfolioId: string) {
+    return this.portfolioService.archivePortfolio(portfolioId);
+  }
+
   @Delete("portfolios/:id")
   @HttpCode(HttpStatus.NO_CONTENT)
-  @ApiOperation({ summary: "Delete portfolio" })
+  @ApiOperation({ summary: "Soft-delete portfolio" })
   @UseGuards(PortfolioOwnerGuard)
   async deletePortfolio(@Param("id") portfolioId: string) {
     return this.portfolioService.deletePortfolio(portfolioId);

--- a/src/portfolio/services/portfolio.service.spec.ts
+++ b/src/portfolio/services/portfolio.service.spec.ts
@@ -1,0 +1,360 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { getRepositoryToken } from "@nestjs/typeorm";
+import { ILike, Not } from "typeorm";
+import { PortfolioService } from "./portfolio.service";
+import {
+  Portfolio,
+  PortfolioStatus,
+  PortfolioType,
+} from "../entities/portfolio.entity";
+import { PortfolioAsset } from "../entities/portfolio-asset.entity";
+import { OptimizationHistory } from "../entities/optimization-history.entity";
+import { RiskProfile } from "../entities/risk-profile.entity";
+import {
+  PortfolioNotFoundException,
+  DuplicatePortfolioNameException,
+} from "../exceptions/portfolio.exceptions";
+
+const mockPortfolioRepo = {
+  create: jest.fn(),
+  save: jest.fn(),
+  findOne: jest.fn(),
+  find: jest.fn(),
+  findAndCount: jest.fn(),
+  softDelete: jest.fn(),
+  delete: jest.fn(),
+};
+
+const mockAssetRepo = {
+  find: jest.fn(),
+  findOne: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+};
+
+const mockOptimizationRepo = {
+  find: jest.fn(),
+  findOne: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+};
+
+const mockRiskProfileRepo = {
+  find: jest.fn(),
+  findOne: jest.fn(),
+};
+
+const USER_ID = "user-1";
+
+const buildPortfolio = (overrides: Partial<Portfolio> = {}): Portfolio =>
+  ({
+    id: "pf-1",
+    name: "My Portfolio",
+    description: "desc",
+    status: PortfolioStatus.ACTIVE,
+    type: PortfolioType.BALANCED,
+    totalValue: 0,
+    currentAllocation: {},
+    targetAllocation: {},
+    initialAllocation: {},
+    autoRebalanceEnabled: false,
+    rebalanceThreshold: 5,
+    userId: USER_ID,
+    createdAt: new Date("2026-01-01"),
+    updatedAt: new Date("2026-01-01"),
+    ...overrides,
+  }) as Portfolio;
+
+describe("PortfolioService (CRUD)", () => {
+  let service: PortfolioService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PortfolioService,
+        {
+          provide: getRepositoryToken(Portfolio),
+          useValue: mockPortfolioRepo,
+        },
+        {
+          provide: getRepositoryToken(PortfolioAsset),
+          useValue: mockAssetRepo,
+        },
+        {
+          provide: getRepositoryToken(OptimizationHistory),
+          useValue: mockOptimizationRepo,
+        },
+        {
+          provide: getRepositoryToken(RiskProfile),
+          useValue: mockRiskProfileRepo,
+        },
+      ],
+    }).compile();
+
+    service = module.get<PortfolioService>(PortfolioService);
+    jest.clearAllMocks();
+    mockPortfolioRepo.create.mockImplementation((p) => ({ ...p }));
+    mockPortfolioRepo.save.mockImplementation((p) =>
+      Promise.resolve({ id: "pf-1", ...p }),
+    );
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  describe("createPortfolio", () => {
+    it("creates a portfolio with defaults when no duplicate exists", async () => {
+      mockPortfolioRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.createPortfolio(USER_ID, {
+        name: "Growth Fund",
+      });
+
+      expect(mockPortfolioRepo.findOne).toHaveBeenCalledWith({
+        where: { name: "Growth Fund" },
+      });
+      expect(mockPortfolioRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "Growth Fund",
+          userId: USER_ID,
+          status: PortfolioStatus.ACTIVE,
+          type: PortfolioType.BALANCED,
+        }),
+      );
+      expect(result.id).toBe("pf-1");
+    });
+
+    it("honors a provided type and seeds currentAllocation from initialAllocation", async () => {
+      mockPortfolioRepo.findOne.mockResolvedValue(null);
+
+      await service.createPortfolio(USER_ID, {
+        name: "Aggressive Fund",
+        type: PortfolioType.AGGRESSIVE,
+        initialAllocation: { BTC: 60, ETH: 40 },
+      });
+
+      expect(mockPortfolioRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: PortfolioType.AGGRESSIVE,
+          initialAllocation: { BTC: 60, ETH: 40 },
+          currentAllocation: { BTC: 60, ETH: 40 },
+        }),
+      );
+    });
+
+    it("rejects duplicate portfolio names", async () => {
+      mockPortfolioRepo.findOne.mockResolvedValue(buildPortfolio());
+
+      await expect(
+        service.createPortfolio(USER_ID, { name: "My Portfolio" }),
+      ).rejects.toBeInstanceOf(DuplicatePortfolioNameException);
+      expect(mockPortfolioRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getPortfolio", () => {
+    it("returns the portfolio when found", async () => {
+      const pf = buildPortfolio();
+      mockPortfolioRepo.findOne.mockResolvedValue(pf);
+
+      const result = await service.getPortfolio("pf-1");
+
+      expect(result).toBe(pf);
+      expect(mockPortfolioRepo.findOne).toHaveBeenCalledWith({
+        where: { id: "pf-1" },
+        relations: ["assets", "optimizationHistory", "performanceMetrics"],
+      });
+    });
+
+    it("throws when the portfolio does not exist", async () => {
+      mockPortfolioRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.getPortfolio("missing")).rejects.toBeInstanceOf(
+        PortfolioNotFoundException,
+      );
+    });
+  });
+
+  describe("getUserPortfolios", () => {
+    it("returns all portfolios for a user ordered by createdAt", async () => {
+      const items = [buildPortfolio()];
+      mockPortfolioRepo.find.mockResolvedValue(items);
+
+      const result = await service.getUserPortfolios(USER_ID);
+
+      expect(result).toBe(items);
+      expect(mockPortfolioRepo.find).toHaveBeenCalledWith({
+        where: { userId: USER_ID },
+        relations: ["assets", "performanceMetrics"],
+        order: { createdAt: "DESC" },
+      });
+    });
+  });
+
+  describe("listPortfolios", () => {
+    it("paginates with defaults and computes totalPages", async () => {
+      const items = [buildPortfolio(), buildPortfolio({ id: "pf-2" })];
+      mockPortfolioRepo.findAndCount.mockResolvedValue([items, 2]);
+
+      const result = await service.listPortfolios(USER_ID);
+
+      expect(mockPortfolioRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId: USER_ID },
+          skip: 0,
+          take: 20,
+          order: { createdAt: "DESC" },
+        }),
+      );
+      expect(result.total).toBe(2);
+      expect(result.page).toBe(1);
+      expect(result.limit).toBe(20);
+      expect(result.totalPages).toBe(1);
+    });
+
+    it("applies status, type and search filters with paging math", async () => {
+      mockPortfolioRepo.findAndCount.mockResolvedValue([[], 0]);
+
+      await service.listPortfolios(USER_ID, {
+        status: PortfolioStatus.ACTIVE,
+        type: PortfolioType.CONSERVATIVE,
+        search: "retire",
+        page: 3,
+        limit: 10,
+      });
+
+      expect(mockPortfolioRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            userId: USER_ID,
+            status: PortfolioStatus.ACTIVE,
+            type: PortfolioType.CONSERVATIVE,
+            name: ILike("%retire%"),
+          },
+          skip: 20,
+          take: 10,
+        }),
+      );
+    });
+
+    it("reports zero totalPages for an empty result set", async () => {
+      mockPortfolioRepo.findAndCount.mockResolvedValue([[], 0]);
+
+      const result = await service.listPortfolios(USER_ID, { limit: 5 });
+
+      expect(result.totalPages).toBe(0);
+      expect(result.total).toBe(0);
+    });
+  });
+
+  describe("updatePortfolio", () => {
+    it("updates fields without re-validating an unchanged name", async () => {
+      const pf = buildPortfolio();
+      mockPortfolioRepo.findOne.mockResolvedValue(pf);
+
+      await service.updatePortfolio("pf-1", {
+        description: "updated",
+        type: PortfolioType.CONSERVATIVE,
+      });
+
+      // findOne only called once (the getPortfolio lookup), not for uniqueness.
+      expect(mockPortfolioRepo.findOne).toHaveBeenCalledTimes(1);
+      expect(mockPortfolioRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: "updated",
+          type: PortfolioType.CONSERVATIVE,
+        }),
+      );
+    });
+
+    it("validates uniqueness when the name changes", async () => {
+      const pf = buildPortfolio();
+      mockPortfolioRepo.findOne
+        .mockResolvedValueOnce(pf) // getPortfolio
+        .mockResolvedValueOnce(null); // uniqueness check
+
+      await service.updatePortfolio("pf-1", { name: "Brand New Name" });
+
+      expect(mockPortfolioRepo.findOne).toHaveBeenLastCalledWith({
+        where: { name: "Brand New Name", id: Not("pf-1") },
+      });
+      expect(mockPortfolioRepo.save).toHaveBeenCalled();
+    });
+
+    it("rejects renaming to an existing name", async () => {
+      const pf = buildPortfolio();
+      mockPortfolioRepo.findOne
+        .mockResolvedValueOnce(pf) // getPortfolio
+        .mockResolvedValueOnce(buildPortfolio({ id: "pf-2" })); // duplicate
+
+      await expect(
+        service.updatePortfolio("pf-1", { name: "Taken Name" }),
+      ).rejects.toBeInstanceOf(DuplicatePortfolioNameException);
+      expect(mockPortfolioRepo.save).not.toHaveBeenCalled();
+    });
+
+    it("throws when updating a non-existent portfolio", async () => {
+      mockPortfolioRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.updatePortfolio("missing", { description: "x" }),
+      ).rejects.toBeInstanceOf(PortfolioNotFoundException);
+    });
+  });
+
+  describe("archivePortfolio", () => {
+    it("sets status to ARCHIVED and saves", async () => {
+      const pf = buildPortfolio();
+      mockPortfolioRepo.findOne.mockResolvedValue(pf);
+
+      const result = await service.archivePortfolio("pf-1");
+
+      expect(result.status).toBe(PortfolioStatus.ARCHIVED);
+      expect(mockPortfolioRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ status: PortfolioStatus.ARCHIVED }),
+      );
+    });
+  });
+
+  describe("deletePortfolio", () => {
+    it("soft-deletes an existing portfolio", async () => {
+      mockPortfolioRepo.findOne.mockResolvedValue(buildPortfolio());
+      mockPortfolioRepo.softDelete.mockResolvedValue({ affected: 1 });
+
+      await service.deletePortfolio("pf-1");
+
+      expect(mockPortfolioRepo.softDelete).toHaveBeenCalledWith("pf-1");
+    });
+
+    it("throws when deleting a non-existent portfolio", async () => {
+      mockPortfolioRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.deletePortfolio("missing")).rejects.toBeInstanceOf(
+        PortfolioNotFoundException,
+      );
+      expect(mockPortfolioRepo.softDelete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("performance / large portfolios", () => {
+    it("lists a large page of portfolios within a reasonable time", async () => {
+      const large = Array.from({ length: 1000 }, (_, i) =>
+        buildPortfolio({ id: `pf-${i}` }),
+      );
+      mockPortfolioRepo.findAndCount.mockResolvedValue([large, 5000]);
+
+      const start = Date.now();
+      const result = await service.listPortfolios(USER_ID, {
+        page: 1,
+        limit: 1000,
+      });
+      const elapsed = Date.now() - start;
+
+      expect(result.data).toHaveLength(1000);
+      expect(result.total).toBe(5000);
+      expect(result.totalPages).toBe(5);
+      expect(elapsed).toBeLessThan(1000);
+    });
+  });
+});

--- a/src/portfolio/services/portfolio.service.ts
+++ b/src/portfolio/services/portfolio.service.ts
@@ -2,9 +2,10 @@ import { Injectable, Logger, BadRequestException } from "@nestjs/common";
 import {
   OptimizationFailedException,
   PortfolioNotFoundException,
+  DuplicatePortfolioNameException,
 } from "../exceptions/portfolio.exceptions";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Repository } from "typeorm";
+import { ILike, Not, Repository } from "typeorm";
 import { Portfolio } from "../entities/portfolio.entity";
 import { PortfolioAsset } from "../entities/portfolio-asset.entity";
 import {
@@ -13,9 +14,14 @@ import {
   OptimizationStatus,
 } from "../entities/optimization-history.entity";
 import { RiskProfile } from "../entities/risk-profile.entity";
-import { CreatePortfolioDto, UpdatePortfolioDto } from "../dto/portfolio.dto";
+import {
+  CreatePortfolioDto,
+  UpdatePortfolioDto,
+  QueryPortfolioDto,
+  PaginatedPortfoliosDto,
+} from "../dto/portfolio.dto";
 import { CreateOptimizationDto } from "../dto/optimization.dto";
-import { PortfolioStatus } from "../entities/portfolio.entity";
+import { PortfolioStatus, PortfolioType } from "../entities/portfolio.entity";
 import { ModernPortfolioTheory } from "../algorithms/modern-portfolio-theory";
 import { BlackLittermanModel } from "../algorithms/black-litterman";
 import { ConstraintOptimizer } from "../algorithms/constraint-optimizer";
@@ -36,21 +42,34 @@ export class PortfolioService {
   ) {}
 
   /**
-   * Create a new portfolio for a user
+   * Create a new portfolio for a user.
+   *
+   * Validates that the portfolio name is unique and applies sensible
+   * defaults (status, type and allocation maps) before persisting.
    */
   async createPortfolio(
     userId: string,
     dto: CreatePortfolioDto,
   ): Promise<Portfolio> {
+    this.logger.log(`Creating portfolio "${dto.name}" for user ${userId}`);
+
+    await this.assertNameIsUnique(dto.name);
+
+    const initialAllocation = dto.initialAllocation || {};
+
     const portfolio = this.portfolioRepository.create({
       ...dto,
       userId,
       status: PortfolioStatus.ACTIVE,
-      currentAllocation: {},
+      type: dto.type || PortfolioType.BALANCED,
+      initialAllocation,
+      currentAllocation: { ...initialAllocation },
       targetAllocation: {},
     });
 
-    return this.portfolioRepository.save(portfolio);
+    const saved = await this.portfolioRepository.save(portfolio);
+    this.logger.log(`Portfolio ${saved.id} created for user ${userId}`);
+    return saved;
   }
 
   /**
@@ -81,7 +100,45 @@ export class PortfolioService {
   }
 
   /**
-   * Update portfolio
+   * List a user's portfolios with pagination and optional filtering.
+   *
+   * Supports filtering by status, type and a case-insensitive name search.
+   * Soft-deleted portfolios are excluded automatically.
+   */
+  async listPortfolios(
+    userId: string,
+    query: QueryPortfolioDto = {},
+  ): Promise<PaginatedPortfoliosDto> {
+    const page = query.page && query.page > 0 ? query.page : 1;
+    const limit = query.limit && query.limit > 0 ? query.limit : 20;
+
+    const where: Record<string, unknown> = { userId };
+    if (query.status) where.status = query.status;
+    if (query.type) where.type = query.type;
+    if (query.search) where.name = ILike(`%${query.search}%`);
+
+    const [data, total] = await this.portfolioRepository.findAndCount({
+      where,
+      relations: ["assets", "performanceMetrics"],
+      order: { createdAt: "DESC" },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+
+    return {
+      data: data as unknown as PaginatedPortfoliosDto["data"],
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit) || 0,
+    };
+  }
+
+  /**
+   * Update portfolio.
+   *
+   * When the name changes it is re-validated for uniqueness against other
+   * portfolios.
    */
   async updatePortfolio(
     portfolioId: string,
@@ -89,9 +146,28 @@ export class PortfolioService {
   ): Promise<Portfolio> {
     const portfolio = await this.getPortfolio(portfolioId);
 
+    if (dto.name && dto.name !== portfolio.name) {
+      await this.assertNameIsUnique(dto.name, portfolioId);
+    }
+
     Object.assign(portfolio, dto);
 
-    return this.portfolioRepository.save(portfolio);
+    const saved = await this.portfolioRepository.save(portfolio);
+    this.logger.log(`Portfolio ${portfolioId} updated`);
+    return saved;
+  }
+
+  /**
+   * Archive a portfolio (soft delete via status change).
+   *
+   * The record is retained for historical reporting but flagged as archived.
+   */
+  async archivePortfolio(portfolioId: string): Promise<Portfolio> {
+    const portfolio = await this.getPortfolio(portfolioId);
+    portfolio.status = PortfolioStatus.ARCHIVED;
+    const saved = await this.portfolioRepository.save(portfolio);
+    this.logger.log(`Portfolio ${portfolioId} archived`);
+    return saved;
   }
 
   /**
@@ -414,9 +490,35 @@ export class PortfolioService {
   }
 
   /**
-   * Delete portfolio
+   * Soft-delete a portfolio.
+   *
+   * Uses TypeORM soft removal so the row is retained (with a `deletedAt`
+   * timestamp) and excluded from subsequent queries.
    */
   async deletePortfolio(portfolioId: string): Promise<void> {
-    await this.portfolioRepository.delete(portfolioId);
+    // Ensure it exists (and is not already removed) before deleting.
+    await this.getPortfolio(portfolioId);
+    await this.portfolioRepository.softDelete(portfolioId);
+    this.logger.log(`Portfolio ${portfolioId} soft-deleted`);
+  }
+
+  /**
+   * Ensure no other portfolio already uses the given name.
+   *
+   * @param name        The candidate portfolio name.
+   * @param excludeId   Optional portfolio id to exclude (used on update).
+   */
+  private async assertNameIsUnique(
+    name: string,
+    excludeId?: string,
+  ): Promise<void> {
+    const existing = await this.portfolioRepository.findOne({
+      where: excludeId ? { name, id: Not(excludeId) } : { name },
+    });
+
+    if (existing) {
+      this.logger.warn(`Duplicate portfolio name rejected: "${name}"`);
+      throw new DuplicatePortfolioNameException(name);
+    }
   }
 }


### PR DESCRIPTION
Closes #316 

## Summary
Implements the Portfolio Service CRUD operations with full validation and business logic

Builds on the existing `src/portfolio` module — extends the `PortfolioService`, entity, DTOs, exceptions, and controller rather than duplicating them.

## Changes
- **Create** — `createPortfolio` now validates name uniqueness, applies a portfolio `type` (default `balanced`), and seeds `currentAllocation` from the provided `initialAllocation`.
- **Read** — `getPortfolio` (details + holdings + performance relations) and a new `listPortfolios` with pagination and filtering.
- **Update** — `updatePortfolio` re-validates name uniqueness only when the name changes.
- **Delete / Archive** — `deletePortfolio` is now a **soft delete** (`@DeleteDateColumn deletedAt`); added `archivePortfolio` which sets status to `archived`.
- **List** — `GET /portfolio/portfolios` supports `page`, `limit`, `status`, `type`, and case-insensitive `search` via `QueryPortfolioDto`, returning a paginated envelope (`data`, `total`, `page`, `limit`, `totalPages`).
- **Validation** — name length (3–100 chars) enforced in DTO; duplicate names rejected with a new `DuplicatePortfolioNameException` (HTTP 409).
- **Types** — new `PortfolioType` enum: `balanced`, `aggressive`, `conservative`.
- **Logging** — integrated `Logger` calls across all CRUD operations.
- **Timestamps** — creation/modification tracked via existing `@CreateDateColumn`/`@UpdateDateColumn`.

## Acceptance Criteria
- [x] Create portfolio with name, type, initial allocation
- [x] Read portfolio details, holdings, performance metrics
- [x] Update portfolio properties and allocation strategy
- [x] Delete/archive portfolio (soft delete)
- [x] List portfolios with pagination and filtering
- [x] Validate portfolio name (unique, 3–100 chars)
- [x] Track creation and modification timestamps
- [x] Support multiple portfolio types (balanced, aggressive, conservative)

## Tests
Added `src/portfolio/services/portfolio.service.spec.ts` — **18 unit tests, all passing**:
- Each CRUD operation (create, read, list, update, archive, delete)
- Edge cases: duplicate names on create and rename, not-found on read/update/delete, empty result pagination
- Performance test for a large (1000-item) portfolio page

```bash
npx jest src/portfolio/services/portfolio.service.spec.ts
# Tests: 18 passed, 18 total
